### PR TITLE
Add standalone method and some code refactoring

### DIFF
--- a/data_plotly.py
+++ b/data_plotly.py
@@ -194,6 +194,9 @@ class DataPlotly:
             pass
 
     def loadPlot(self, plot_dic):
+        '''
+        call the method to load the DataPlotly dialog with a given dictionary
+        '''
 
         self.dlg.showPlot(plot_dic)
         self.run()

--- a/data_plotly.py
+++ b/data_plotly.py
@@ -192,3 +192,8 @@ class DataPlotly:
             # Do something useful here - delete the line containing pass and
             # substitute with your code.
             pass
+
+    def loadPlot(self, plot_dic):
+
+        self.dlg.showPlot(plot_dic)
+        self.run()

--- a/data_plotly_dialog.py
+++ b/data_plotly_dialog.py
@@ -641,72 +641,75 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
         # get the plot type from the combo box
         self.ptype = self.plot_types2[self.plot_combo.currentText()]
 
-        # plot instance
-        self.plotobject = Plot()
+        # # plot instance
+        # self.plotobject = Plot()
 
         # shortcut to clear the code in the following dictionary
         xx = self.layer_combo.currentLayer().getValues(self.x_combo.currentText(), selectedOnly=self.selected_feature_check.isChecked())[0]
         yy = self.layer_combo.currentLayer().getValues(self.y_combo.currentText(), selectedOnly=self.selected_feature_check.isChecked())[0]
         zz = self.layer_combo.currentLayer().getValues(self.z_combo.currentText(), selectedOnly=self.selected_feature_check.isChecked())[0]
 
-        # plot method to have a dictionary of the properties
-        self.plotobject.buildProperties(
-            x=xx,
-            y=yy,
-            z=zz,
+        # dictionary of all the plot properties
+        plot_properties = {
+            'x':xx,
+            'y':yy,
+            'z':zz,
             # featureIds are the ID of each feature needed for the selection and zooming method
-            featureIds=getIds(self.layer_combo.currentLayer()),
-            featureBox=getSortedId(self.layer_combo.currentLayer(), xx),
-            custom=self.x_combo.currentText(),
-            hover_text=self.info_hover[self.info_combo.currentText()],
-            additional_hover_text=self.layer_combo.currentLayer().getValues(self.additional_info_combo.currentText(), selectedOnly=self.selected_feature_check.isChecked())[0],
-            x_name=self.x_combo.currentText(),
-            y_name=self.y_combo.currentText(),
-            z_name=self.z_combo.currentText(),
-            in_color=hex_to_rgb(self.in_color_combo),
-            out_color=hex_to_rgb(self.out_color_combo),
-            marker_width=self.marker_width.value(),
-            marker_size=self.marker_size.value(),
-            marker_symbol=self.point_types2[self.point_combo.currentData()],
-            line_dash=self.line_types2[self.line_combo.currentText()],
-            box_orientation=self.orientation_box[self.orientation_combo.currentText()],
-            marker=self.marker_types[self.marker_type_combo.currentText()],
-            opacity=(100 - self.alpha_slid.value()) / 100.0,
-            box_stat=self.statistic_type[self.box_statistic_combo.currentText()],
-            box_outliers=self.outliers_dict[self.outliers_combo.currentText()],
-            name=self.legend_title.text(),
-            normalization=self.normalization[self.hist_norm_combo.currentText()],
-            cont_type=self.contour_type[self.contour_type_combo.currentText()],
-            color_scale=self.col_scale[self.color_scale_combo.currentText()],
-            show_lines=self.show_lines_check.isChecked()
-        )
-
-
-        # build the final trace that will be used
-        self.plotobject.buildTrace(
-            plot_type=self.ptype
-        )
+            'featureIds':getIds(self.layer_combo.currentLayer()),
+            'featureBox':getSortedId(self.layer_combo.currentLayer(), xx),
+            'custom':self.x_combo.currentText(),
+            'hover_text':self.info_hover[self.info_combo.currentText()],
+            'additional_hover_text':self.layer_combo.currentLayer().getValues(self.additional_info_combo.currentText(), selectedOnly=self.selected_feature_check.isChecked())[0],
+            'x_name':self.x_combo.currentText(),
+            'y_name':self.y_combo.currentText(),
+            'z_name':self.z_combo.currentText(),
+            'in_color':hex_to_rgb(self.in_color_combo),
+            'out_color':hex_to_rgb(self.out_color_combo),
+            'marker_width':self.marker_width.value(),
+            'marker_size':self.marker_size.value(),
+            'marker_symbol':self.point_types2[self.point_combo.currentData()],
+            'line_dash':self.line_types2[self.line_combo.currentText()],
+            'box_orientation':self.orientation_box[self.orientation_combo.currentText()],
+            'marker':self.marker_types[self.marker_type_combo.currentText()],
+            'opacity':(100 - self.alpha_slid.value()) / 100.0,
+            'box_stat':self.statistic_type[self.box_statistic_combo.currentText()],
+            'box_outliers':self.outliers_dict[self.outliers_combo.currentText()],
+            'name':self.legend_title.text(),
+            'normalization':self.normalization[self.hist_norm_combo.currentText()],
+            'cont_type':self.contour_type[self.contour_type_combo.currentText()],
+            'color_scale':self.col_scale[self.color_scale_combo.currentText()],
+            'show_lines':self.show_lines_check.isChecked()
+        }
 
 
         # build the layout customizations
-        self.plotobject.layoutProperties(
-            legend=self.show_legend_check.isChecked(),
-            title=self.plot_title_line.text(),
-            x_title=self.x_axis_title.text(),
-            y_title=self.y_axis_title.text(),
-            z_title=self.z_axis_title.text(),
-            range_slider=dict(visible=self.range_slider_combo.isChecked(), borderwidth=1),
-            bar_mode=self.bar_modes[self.bar_mode_combo.currentText()],
-            x_type=self.x_axis_type[self.x_axis_mode_combo.currentText()],
-            y_type=self.y_axis_type[self.y_axis_mode_combo.currentText()],
-            x_inv=self.x_invert,
-            y_inv=self.y_invert,
-        )
+        layout_properties = {
+            'legend':self.show_legend_check.isChecked(),
+            'title':self.plot_title_line.text(),
+            'x_title':self.x_axis_title.text(),
+            'y_title':self.y_axis_title.text(),
+            'z_title':self.z_axis_title.text(),
+            'range_slider':dict(visible=self.range_slider_combo.isChecked(), borderwidth=1),
+            'bar_mode':self.bar_modes[self.bar_mode_combo.currentText()],
+            'x_type':self.x_axis_type[self.x_axis_mode_combo.currentText()],
+            'y_type':self.y_axis_type[self.y_axis_mode_combo.currentText()],
+            'x_inv':self.x_invert,
+            'y_inv':self.y_invert,
+        }
+
+
+        # plot instance
+        self.plotobject = Plot(self.ptype, plot_properties, layout_properties)
+
+        # build the final trace that will be used
+        self.plotobject.buildTrace()
+
+        print(self.plotobject.trace)
 
         # call the method and build the final layout
-        self.plotobject.buildLayout(
-            plot_type=self.ptype
-        )
+        self.plotobject.buildLayout()
+
+        print(self.plotobject.layout)
 
         # unique name for each plot trace (name is idx_plot, e.g. 1_scatter)
         self.pid = ('{}_{}'.format(str(self.idx), self.ptype))
@@ -731,8 +734,6 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
 
         # call the method to build all the Plot plotProperties
         self.plotProperties()
-
-        print (dir(self.plot_traces['1_scatter']))
 
 
         if not self.plot_traces:
@@ -994,20 +995,16 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
             if k not in plot_input_dic["layout_prop"]:
                 plot_input_dic["layout_prop"][k] = plot_dic["layout_prop"][k]
 
+
+        plot_type=plot_input_dic['plot_type']
         # create Plot instance
-        plot_standalone = Plot()
+        plot_standalone = Plot(plot_type, plot_input_dic["plot_prop"], plot_input_dic["layout_prop"])
 
         # initialize plot properties and build them
-        plot_standalone.buildProperties(**plot_input_dic["plot_prop"])
-        plot_standalone.buildTrace(
-            plot_type=plot_input_dic['plot_type']
-        )
+        plot_standalone.buildTrace()
 
         # initialize layout properties and build them
-        plot_standalone.layoutProperties(**plot_input_dic["layout_prop"])
-        plot_standalone.buildLayout(
-            plot_type=plot_input_dic['plot_type']
-        )
+        plot_standalone.buildLayout()
 
         standalone_plot_path = plot_standalone.buildFigure(plot_type=plot_input_dic['plot_type'])
         standalone_plot_url = QUrl.fromLocalFile(standalone_plot_path)

--- a/data_plotly_dialog.py
+++ b/data_plotly_dialog.py
@@ -136,6 +136,7 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
         self.z_combo.fieldChanged.connect(self.setLegend)
 
         self.draw_btn.clicked.connect(self.createPlot)
+        self.update_btn.clicked.connect(self.UpdatePlot)
         self.clear_btn.clicked.connect(self.clearPlotView)
         self.save_plot_btn.clicked.connect(self.savePlotAsImage)
         self.save_plot_html_btn.clicked.connect(self.savePlotAsHtml)
@@ -720,24 +721,11 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
         # create default dictionary that contains all the plot and properties
         self.plot_traces[self.pid] = self.plotobject
 
-        # call the function and fill the table
-        # self.addTraceToTable()
-
         # just add 1 to the index
         self.idx += 1
 
-    def addTraceToTable(self):
-        '''
-        add the created trace to the table traceTable
-        '''
-        row = self.traceTable.rowCount()
-        self.traceTable.insertRow(row)
-
-        # fill the table with each paramter entered
-        self.traceTable.setItem(row, 0, QTableWidgetItem(str(self.pid)))
-        self.traceTable.setItem(row, 1, QTableWidgetItem(str(self.ptype)))
-        self.traceTable.setItem(row, 2, QTableWidgetItem(str(self.x_combo.currentText())))
-        self.traceTable.setItem(row, 3, QTableWidgetItem(str(self.y_combo.currentText())))
+        # enable the Update Plot button
+        self.update_btn.setEnabled(True)
 
 
     def createPlot(self):
@@ -802,6 +790,17 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
         # connect to simple function that reloads the view
         self.refreshPlotView()
 
+    def UpdatePlot(self):
+        '''
+        simple method to update the plot in the Plot Canvas
+        it just calls 2 existing methods
+        '''
+
+        self.clearPlotView()
+        self.createPlot()
+
+
+
     def refreshPlotView(self):
         '''
         just resfresh the view, if the reload method is called immediatly after
@@ -831,6 +830,8 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
             self.plot_view.load(QUrl(''))
             self.layoutw.addWidget(self.plot_view)
             self.raw_plot_text.clear()
+            # disable the Update Plot Button
+            self.update_btn.setEnabled(False)
         except:
             pass
 
@@ -878,7 +879,7 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
 
     def showPlot(self, plot_input_dic):
         '''
-        creates a simple plot (not all he options available) from a dictionary
+        creates a simple plot (not all options available) from a dictionary
         as input
         '''
 
@@ -889,6 +890,7 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
         # plot properties
         plot_dic = {}
         plot_dic["plot_type"]=None
+        plot_dic["layer"]=None
         plot_dic["plot_prop"] = {}
         plot_dic["plot_prop"]["x"]=None
         plot_dic["plot_prop"]["y"]=None
@@ -926,7 +928,6 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
         plot_dic["layout_prop"]["y_title"]=None
         plot_dic["layout_prop"]["z_title"]=None
         plot_dic["layout_prop"]["xaxis"] = None
-        # plot_dic["layout_prop"]["xaxis"]["rangeslider"]={"visible" = False}
         plot_dic["layout_prop"]["range_slider"]=None
         plot_dic["layout_prop"]["bar_mode"]=None
         plot_dic["layout_prop"]["x_type"]=None
@@ -934,14 +935,20 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
         plot_dic["layout_prop"]["x_inv"]=None
         plot_dic["layout_prop"]["y_inv"]=None
 
-        print(plot_dic["plot_prop"])
+
+        # set some dialog widget from the input dictionary
+        # self.plot_combo.clear()
+        for k, v in self.plot_types.items():
+            if self.plot_types[k] == plot_input_dic["plot_type"]:
+                self.plot_combo.addItem(k, v)
+        self.layer_combo.setLayer(plot_input_dic["layer"])
+        self.x_combo.setField(plot_input_dic["plot_prop"]["x_name"])
+        self.y_combo.setField(plot_input_dic["plot_prop"]["y_name"])
 
         # update the plot_prop
         for k in plot_dic["plot_prop"]:
             if k not in plot_input_dic["plot_prop"]:
                 plot_input_dic["plot_prop"][k] = plot_dic["plot_prop"][k]
-
-        print(plot_input_dic["plot_prop"])
 
         # update the layout_prop
         for k in plot_dic["layout_prop"]:
@@ -968,3 +975,5 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
 
         self.plot_view.load(standalone_plot_url)
         self.layoutw.addWidget(self.plot_view)
+
+        self.update_btn.setEnabled(True)

--- a/data_plotly_dialog.py
+++ b/data_plotly_dialog.py
@@ -796,6 +796,7 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
         it just calls 2 existing methods
         '''
 
+        print(self.plot_traces)
         self.clearPlotView()
         self.createPlot()
 
@@ -928,12 +929,13 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
         plot_dic["layout_prop"]["y_title"]=None
         plot_dic["layout_prop"]["z_title"]=None
         plot_dic["layout_prop"]["xaxis"] = None
-        plot_dic["layout_prop"]["range_slider"]=None
         plot_dic["layout_prop"]["bar_mode"]=None
         plot_dic["layout_prop"]["x_type"]=None
         plot_dic["layout_prop"]["y_type"]=None
         plot_dic["layout_prop"]["x_inv"]=None
         plot_dic["layout_prop"]["y_inv"]=None
+        plot_dic['layout_prop']["range_slider"] = {}
+        plot_dic['layout_prop']["range_slider"]["visible"] = False
 
 
         # set some dialog widget from the input dictionary
@@ -976,4 +978,5 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
         self.plot_view.load(standalone_plot_url)
         self.layoutw.addWidget(self.plot_view)
 
+        # enable the Update Button to allow the updating of the plot
         self.update_btn.setEnabled(True)

--- a/data_plotly_dialog.py
+++ b/data_plotly_dialog.py
@@ -917,3 +917,39 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
         if self.plot_file:
             copyfile(self.plot_path, self.plot_file)
             self.bar.pushMessage(self.tr("Plot succesfully saved"), level=QgsMessageBar.INFO, duration=2)
+
+
+    def showPlot(self, plot_dict, lay_dict):
+        '''
+        creates a simple plot (not all he options available) from a dictionary
+        as input
+        '''
+
+        plot = Plot()
+        plot.buildProperties(**plot_dict["plot_prop"])
+        plot.buildTrace(
+            plot_type=plot_dict['plot_type']
+        )
+        plot.layoutProperties(**lay_dict)
+        plot.buildLayout(
+            plot_type=plot_dict['plot_type']
+        )
+
+        standalone_plot_path = plot.buildFigure(plot_type=plot_dict['plot_type'])
+        standalone_plot_url = QUrl.fromLocalFile(standalone_plot_path)
+
+
+        # start and create the webview with the plot
+        plot_view2 = QWebView()
+        plot_view2.page().setNetworkAccessManager(QgsNetworkAccessManager.instance())
+        plot_view_settings2 = plot_view2.settings()
+        plot_view_settings2.setAttribute(QWebSettings.WebGLEnabled, True)
+        plot_view_settings2.setAttribute(QWebSettings.DeveloperExtrasEnabled, True)
+        plot_view_settings2.setAttribute(QWebSettings.Accelerated2dCanvasEnabled, True)
+
+
+        # plot_path2 = '/home/matteo/plotly2.html'
+        global plot_view2
+        # plot_url2 = QUrl.fromLocalFile(plot_path2)
+        plot_view2.load(standalone_plot_url)
+        plot_view2.show()

--- a/data_plotly_dialog.py
+++ b/data_plotly_dialog.py
@@ -651,13 +651,11 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
 
         # plot method to have a dictionary of the properties
         self.plotobject.buildProperties(
-            # x=getFields(self.layer_combo, self.x_combo),
             x=xx,
             y=yy,
             z=zz,
             # featureIds are the ID of each feature needed for the selection and zooming method
             featureIds=getIds(self.layer_combo.currentLayer()),
-            # featureBox=sorted(set(xx), key=xx.index),
             featureBox=getSortedId(self.layer_combo.currentLayer(), xx),
             custom=self.x_combo.currentText(),
             hover_text=self.info_hover[self.info_combo.currentText()],
@@ -689,11 +687,6 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
             plot_type=self.ptype
         )
 
-
-        # ff = getIdJs(self.layer_combo.currentLayer(), self.x_combo.currentText())
-        # print(ff)
-
-        # print(getSortedId(self.layer_combo.currentLayer(), xx))
 
         # build the layout customizations
         self.plotobject.layoutProperties(
@@ -739,6 +732,9 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
         # call the method to build all the Plot plotProperties
         self.plotProperties()
 
+        print (dir(self.plot_traces['1_scatter']))
+
+
         if not self.plot_traces:
             self.bar.pushMessage(self.tr("Basket is empty, add some plot!"),
                                  level=QgsMessageBar.CRITICAL, duration=2)
@@ -783,7 +779,7 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
 
                     self.plot_path = self.plotobject.buildSubPlots('col', gr, 1, pl, tt)
             except:
-                self.bar.pushMessage(self.tr("Plot types are not comapatible for subplotting. Please remove the plot from the Plot Basket"),
+                self.bar.pushMessage(self.tr("Plot types are not comapatible for subplotting"),
                              level=QgsMessageBar.CRITICAL, duration=3)
                 return
 
@@ -796,8 +792,16 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
         it just calls 2 existing methods
         '''
 
+        print(sorted(self.plot_traces.keys())[-1])
+
+
+        del sorted(self.plot_traces.keys())[-1]
+
+        print(sorted(self.plot_traces.keys())[-1])
+
         print(self.plot_traces)
-        self.clearPlotView()
+
+        # self.clearPlotView()
         self.createPlot()
 
 
@@ -882,6 +886,31 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
         '''
         creates a simple plot (not all options available) from a dictionary
         as input
+
+        Code usage example:
+
+        #import the plugins of QGIS
+        from qgis.utils import plugins
+        # create the instace of the plugin
+        myplugin = plugins['DataPlotly']
+
+        # create a dictionary of values that will be elaborated by the method
+
+        vl = iface.activeLayer()
+        # empty dictionary that should filled up with GUI values
+        dq = {}
+        dq['plot_prop'] = {}
+        dq['layout_prop'] = {}
+        # plot type
+        dq['plot_type'] = 'scatter'
+        # vector layer
+        dq["layer"] = vl
+        # minimum X and Y axis values
+        dq['plot_prop']['x'] = [i["some_field"] for i in vl.getFeatures()]
+        dq['plot_prop']['y'] = [i["some_field"] for i in vl.getFeatures()]
+
+        # call the final method
+        myplugin.loadPlot(dq)
         '''
 
 
@@ -948,9 +977,12 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
                         self.plot_combo.setItemText(ii, k)
                         self.plot_combo.setCurrentIndex(ii)
 
-        self.layer_combo.setLayer(plot_input_dic["layer"])
-        self.x_combo.setField(plot_input_dic["plot_prop"]["x_name"])
-        self.y_combo.setField(plot_input_dic["plot_prop"]["y_name"])
+        try:
+            self.layer_combo.setLayer(plot_input_dic["layer"])
+            self.x_combo.setField(plot_input_dic["plot_prop"]["x_name"])
+            self.y_combo.setField(plot_input_dic["plot_prop"]["y_name"])
+        except:
+            pass
 
         # update the plot_prop
         for k in plot_dic["plot_prop"]:
@@ -999,4 +1031,4 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
         # just add 1 to the index
         self.idx += 1
 
-        print(self.plot_traces)
+        print(sorted(self.plot_traces.keys())[-1])

--- a/data_plotly_dialog.py
+++ b/data_plotly_dialog.py
@@ -641,10 +641,7 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
         # get the plot type from the combo box
         self.ptype = self.plot_types2[self.plot_combo.currentText()]
 
-        # # plot instance
-        # self.plotobject = Plot()
-
-        # shortcut to clear the code in the following dictionary
+        # shortcut to shorten the code in the following dictionary
         xx = self.layer_combo.currentLayer().getValues(self.x_combo.currentText(), selectedOnly=self.selected_feature_check.isChecked())[0]
         yy = self.layer_combo.currentLayer().getValues(self.y_combo.currentText(), selectedOnly=self.selected_feature_check.isChecked())[0]
         zz = self.layer_combo.currentLayer().getValues(self.z_combo.currentText(), selectedOnly=self.selected_feature_check.isChecked())[0]
@@ -704,12 +701,8 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
         # build the final trace that will be used
         self.plotobject.buildTrace()
 
-        print(self.plotobject.trace)
-
         # call the method and build the final layout
         self.plotobject.buildLayout()
-
-        print(self.plotobject.layout)
 
         # unique name for each plot trace (name is idx_plot, e.g. 1_scatter)
         self.pid = ('{}_{}'.format(str(self.idx), self.ptype))
@@ -793,14 +786,7 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
         it just calls 2 existing methods
         '''
 
-        print(sorted(self.plot_traces.keys())[-1])
-
-
-        del sorted(self.plot_traces.keys())[-1]
-
-        print(sorted(self.plot_traces.keys())[-1])
-
-        print(self.plot_traces)
+        # print(self.plot_traces['1_scatter'].trace[0]['x'])
 
         # self.clearPlotView()
         self.createPlot()
@@ -996,7 +982,9 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
                 plot_input_dic["layout_prop"][k] = plot_dic["layout_prop"][k]
 
 
+        # get the plot type from the input dictionary
         plot_type=plot_input_dic['plot_type']
+
         # create Plot instance
         plot_standalone = Plot(plot_type, plot_input_dic["plot_prop"], plot_input_dic["layout_prop"])
 
@@ -1015,7 +1003,6 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
         # enable the Update Button to allow the updating of the plot
         self.update_btn.setEnabled(True)
 
-
         # the following code is necessary to let the user add other plots in
         # different plot canvas after the creation of the standolone plot
 
@@ -1027,5 +1014,3 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
 
         # just add 1 to the index
         self.idx += 1
-
-        print(sorted(self.plot_traces.keys())[-1])

--- a/data_plotly_dialog.py
+++ b/data_plotly_dialog.py
@@ -874,6 +874,8 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
         creates a simple plot (not all options available) from a dictionary
         as input
 
+        plot_input_dic has to be a dictionary with some fixed keys, see below 
+
         Code usage example:
 
         #import the plugins of QGIS

--- a/data_plotly_dialog.py
+++ b/data_plotly_dialog.py
@@ -963,21 +963,21 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
                 plot_input_dic["layout_prop"][k] = plot_dic["layout_prop"][k]
 
         # create Plot instance
-        plot = Plot()
+        plot_standalone = Plot()
 
         # initialize plot properties and build them
-        plot.buildProperties(**plot_input_dic["plot_prop"])
-        plot.buildTrace(
+        plot_standalone.buildProperties(**plot_input_dic["plot_prop"])
+        plot_standalone.buildTrace(
             plot_type=plot_input_dic['plot_type']
         )
 
         # initialize layout properties and build them
-        plot.layoutProperties(**plot_input_dic["layout_prop"])
-        plot.buildLayout(
+        plot_standalone.layoutProperties(**plot_input_dic["layout_prop"])
+        plot_standalone.buildLayout(
             plot_type=plot_input_dic['plot_type']
         )
 
-        standalone_plot_path = plot.buildFigure(plot_type=plot_input_dic['plot_type'])
+        standalone_plot_path = plot_standalone.buildFigure(plot_type=plot_input_dic['plot_type'])
         standalone_plot_url = QUrl.fromLocalFile(standalone_plot_path)
 
         self.plot_view.load(standalone_plot_url)
@@ -985,3 +985,18 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
 
         # enable the Update Button to allow the updating of the plot
         self.update_btn.setEnabled(True)
+
+
+        # the following code is necessary to let the user add other plots in
+        # different plot canvas after the creation of the standolone plot
+
+        # unique name for each plot trace (name is idx_plot, e.g. 1_scatter)
+        self.pid = ('{}_{}'.format(str(self.idx), plot_input_dic["plot_type"]))
+
+        # create default dictionary that contains all the plot and properties
+        self.plot_traces[self.pid] = plot_standalone
+
+        # just add 1 to the index
+        self.idx += 1
+
+        print(self.plot_traces)

--- a/data_plotly_dialog.py
+++ b/data_plotly_dialog.py
@@ -876,37 +876,95 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
             self.bar.pushMessage(self.tr("Plot succesfully saved"), level=QgsMessageBar.INFO, duration=2)
 
 
-    def showPlot(self, plot_dict, lay_dict):
+    def showPlot(self, plot_input_dic):
         '''
         creates a simple plot (not all he options available) from a dictionary
         as input
         '''
 
+
+        # keys of the nested plot_prop and layout_prop have to be the SAME of
+        # those created in buildProperties and buildLayout method
+        # prepare the default dictionary with None values
+        # plot properties
+        plot_dic = {}
+        plot_dic["plot_type"]=None
+        plot_dic["plot_prop"] = {}
+        plot_dic["plot_prop"]["x"]=None
+        plot_dic["plot_prop"]["y"]=None
+        plot_dic["plot_prop"]["z"]=None,
+        plot_dic["plot_prop"]["marker"]=None
+        plot_dic["plot_prop"]["featureIds"]=None
+        plot_dic["plot_prop"]["featureBox"]=None
+        plot_dic["plot_prop"]["custom"]=None
+        plot_dic["plot_prop"]["hover_text"]=None
+        plot_dic["plot_prop"]["additional_hover_text"]=None
+        plot_dic["plot_prop"]["x_name"]=None
+        plot_dic["plot_prop"]["y_name"]=None
+        plot_dic["plot_prop"]["z_name"]=None
+        plot_dic["plot_prop"]["in_color"]=None
+        plot_dic["plot_prop"]["out_color"]=None
+        plot_dic["plot_prop"]["marker_width"]=None
+        plot_dic["plot_prop"]["marker_size"]=None
+        plot_dic["plot_prop"]["marker_symbol"]=None
+        plot_dic["plot_prop"]["line_dash"]=None
+        plot_dic["plot_prop"]["box_orientation"]=None
+        plot_dic["plot_prop"]["opacity"]=None
+        plot_dic["plot_prop"]["box_stat"]=None
+        plot_dic["plot_prop"]["box_outliers"]=None
+        plot_dic["plot_prop"]["name"]=None
+        plot_dic["plot_prop"]["normalization"]=None
+        plot_dic["plot_prop"]["cont_type"]=None
+        plot_dic["plot_prop"]["color_scale"]=None
+        plot_dic["plot_prop"]["show_lines"]=None
+
+        # layout nested dictionary
+        plot_dic["layout_prop"] = {}
+        plot_dic["layout_prop"]['title']='Plot Title'
+        plot_dic["layout_prop"]['legend']=True
+        plot_dic["layout_prop"]["x_title"]=None
+        plot_dic["layout_prop"]["y_title"]=None
+        plot_dic["layout_prop"]["z_title"]=None
+        plot_dic["layout_prop"]["xaxis"] = None
+        # plot_dic["layout_prop"]["xaxis"]["rangeslider"]={"visible" = False}
+        plot_dic["layout_prop"]["range_slider"]=None
+        plot_dic["layout_prop"]["bar_mode"]=None
+        plot_dic["layout_prop"]["x_type"]=None
+        plot_dic["layout_prop"]["y_type"]=None
+        plot_dic["layout_prop"]["x_inv"]=None
+        plot_dic["layout_prop"]["y_inv"]=None
+
+        print(plot_dic["plot_prop"])
+
+        # update the plot_prop
+        for k in plot_dic["plot_prop"]:
+            if k not in plot_input_dic["plot_prop"]:
+                plot_input_dic["plot_prop"][k] = plot_dic["plot_prop"][k]
+
+        print(plot_input_dic["plot_prop"])
+
+        # update the layout_prop
+        for k in plot_dic["layout_prop"]:
+            if k not in plot_input_dic["layout_prop"]:
+                plot_input_dic["layout_prop"][k] = plot_dic["layout_prop"][k]
+
+        # create Plot instance
         plot = Plot()
-        plot.buildProperties(**plot_dict["plot_prop"])
+
+        # initialize plot properties and build them
+        plot.buildProperties(**plot_input_dic["plot_prop"])
         plot.buildTrace(
-            plot_type=plot_dict['plot_type']
-        )
-        plot.layoutProperties(**lay_dict)
-        plot.buildLayout(
-            plot_type=plot_dict['plot_type']
+            plot_type=plot_input_dic['plot_type']
         )
 
-        standalone_plot_path = plot.buildFigure(plot_type=plot_dict['plot_type'])
+        # initialize layout properties and build them
+        plot.layoutProperties(**plot_input_dic["layout_prop"])
+        plot.buildLayout(
+            plot_type=plot_input_dic['plot_type']
+        )
+
+        standalone_plot_path = plot.buildFigure(plot_type=plot_input_dic['plot_type'])
         standalone_plot_url = QUrl.fromLocalFile(standalone_plot_path)
 
-
-        # start and create the webview with the plot
-        plot_view2 = QWebView()
-        plot_view2.page().setNetworkAccessManager(QgsNetworkAccessManager.instance())
-        plot_view_settings2 = plot_view2.settings()
-        plot_view_settings2.setAttribute(QWebSettings.WebGLEnabled, True)
-        plot_view_settings2.setAttribute(QWebSettings.DeveloperExtrasEnabled, True)
-        plot_view_settings2.setAttribute(QWebSettings.Accelerated2dCanvasEnabled, True)
-
-
-        # plot_path2 = '/home/matteo/plotly2.html'
-        global plot_view2
-        # plot_url2 = QUrl.fromLocalFile(plot_path2)
-        plot_view2.load(standalone_plot_url)
-        plot_view2.show()
+        self.plot_view.load(standalone_plot_url)
+        self.layoutw.addWidget(self.plot_view)

--- a/data_plotly_dialog.py
+++ b/data_plotly_dialog.py
@@ -782,15 +782,15 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
 
     def UpdatePlot(self):
         '''
-        simple method to update the plot in the Plot Canvas
-        it just calls 2 existing methods
+        updates only the LAST plot created
+        get the key of the last plot created and delete it from the plot container
+        and call the method to create the plot with the updated settings
         '''
 
-        # print(self.plot_traces['1_scatter'].trace[0]['x'])
+        plot_to_update = (sorted(self.plot_traces.keys())[-1])
+        del self.plot_traces[plot_to_update]
 
-        # self.clearPlotView()
         self.createPlot()
-
 
 
     def refreshPlotView(self):

--- a/data_plotly_dialog.py
+++ b/data_plotly_dialog.py
@@ -939,10 +939,15 @@ class DataPlotlyDialog(QtWidgets.QDialog, FORM_CLASS):
 
 
         # set some dialog widget from the input dictionary
-        # self.plot_combo.clear()
-        for k, v in self.plot_types.items():
-            if self.plot_types[k] == plot_input_dic["plot_type"]:
-                self.plot_combo.addItem(k, v)
+        # plot type in the plot_combo combobox
+        for k, v in self.plot_types2.items():
+            if self.plot_types2[k] == plot_input_dic["plot_type"]:
+                for ii, kk in enumerate(self.plot_types.keys()):
+                    if self.plot_types[kk] == k:
+                        self.plot_combo.setItemIcon(ii, kk)
+                        self.plot_combo.setItemText(ii, k)
+                        self.plot_combo.setCurrentIndex(ii)
+
         self.layer_combo.setLayer(plot_input_dic["layer"])
         self.x_combo.setField(plot_input_dic["plot_prop"]["x_name"])
         self.y_combo.setField(plot_input_dic["plot_prop"]["y_name"])

--- a/data_plotly_plot.py
+++ b/data_plotly_plot.py
@@ -9,11 +9,11 @@ import re
 
 class Plot(object):
 
-    plot_type = ''
-
-    plot_properties = {}
-
-    plot_layout = {}
+    # plot_type = ''
+    #
+    # plot_properties = {}
+    #
+    # plot_layout = {}
 
     # path of javascript files
     if platform.system() == 'Windows':
@@ -25,27 +25,15 @@ class Plot(object):
         polyfillpath = os.path.join(os.path.dirname(__file__), 'jsscripts/polyfill.min.js')
         plotlypath = os.path.join(os.path.dirname(__file__), 'jsscripts/plotly.min.js')
 
-    def buildProperties(self, *args, **kwargs):
-        '''
-        dictionary with all the plot properties and return the object
 
-        self.plot_properties is final objcet containing all the properties
+    def __init__(self, plot_type, plot_properties, plot_layout):
 
-        Console usage:
+        self.plot_type = plot_type
+        self.plot_properties = plot_properties
+        self.plot_layout = plot_layout
 
-        p = Plot()
-        p.buildProperties(x = ..., )  #all the kwargs arguments
-        print(p.plot_properties) # returns the dictionary with all the values
 
-        {'marker_width': 1, 'marker_size': 10, 'box_outliers': False .......}
-        '''
-
-        for k, v in kwargs.items():
-            self.plot_properties[k] = v
-
-        return self.plot_properties
-
-    def buildTrace(self, *args, **kwargs):
+    def buildTrace(self):
         '''
         build the final trace calling the go.xxx plotly method
         this method here is the one performing the real job
@@ -66,9 +54,10 @@ class Plot(object):
         '''
 
         # retieve the plot_type from the kwargs and assign it to the variable
-        plot_type = kwargs['plot_type']
+        # plot_type = kwargs['plot_type']
 
-        if plot_type == 'scatter':
+
+        if self.plot_type == 'scatter':
 
             self.trace = [go.Scatter(
                 x=self.plot_properties['x'],
@@ -96,7 +85,7 @@ class Plot(object):
                 opacity=self.plot_properties['opacity']
             )]
 
-        elif plot_type == 'box':
+        elif self.plot_type == 'box':
 
             # NULL value in the Field is empty
             if not self.plot_properties['x']:
@@ -123,7 +112,7 @@ class Plot(object):
                 opacity=self.plot_properties['opacity']
             )]
 
-        elif plot_type == 'bar':
+        elif self.plot_type == 'bar':
 
             if self.plot_properties['box_orientation'] == 'h':
                 self.plot_properties['x'], self.plot_properties['y'] = self.plot_properties['y'], self.plot_properties['x']
@@ -145,7 +134,7 @@ class Plot(object):
                 opacity=self.plot_properties['opacity']
             )]
 
-        elif plot_type == 'histogram':
+        elif self.plot_type == 'histogram':
 
             self.trace = [go.Histogram(
                 x=self.plot_properties['x'],
@@ -163,14 +152,14 @@ class Plot(object):
                 opacity=self.plot_properties['opacity']
             )]
 
-        elif plot_type == 'pie':
+        elif self.plot_type == 'pie':
 
             self.trace = [go.Pie(
                 labels=self.plot_properties['x'],
                 values=self.plot_properties['y'],
             )]
 
-        elif plot_type == '2dhistogram':
+        elif self.plot_type == '2dhistogram':
 
             self.trace = [go.Histogram2d(
                 x=self.plot_properties['x'],
@@ -178,7 +167,7 @@ class Plot(object):
                 colorscale=self.plot_properties['color_scale']
             )]
 
-        elif plot_type == 'polar':
+        elif self.plot_type == 'polar':
 
             self.trace = [go.Scatter(
                 r=self.plot_properties['x'],
@@ -202,7 +191,7 @@ class Plot(object):
                 opacity=self.plot_properties['opacity'],
             )]
 
-        elif plot_type == 'ternary':
+        elif self.plot_type == 'ternary':
 
             # prepare the hover text to display if the additional combobox is empty or not
             # this setting is necessary to overwrite the standard hovering labels
@@ -231,7 +220,7 @@ class Plot(object):
                 opacity=self.plot_properties['opacity']
             )]
 
-        elif plot_type == 'contour':
+        elif self.plot_type == 'contour':
 
             self.trace = [go.Contour(
                 z=[self.plot_properties['x'], self.plot_properties['y']],
@@ -245,28 +234,7 @@ class Plot(object):
 
         return self.trace
 
-    def layoutProperties(self, *args, **kwargs):
-        '''
-        build the layout customizations and return the object
-
-        self.plot_layout is the final objcet containing the layout properties
-
-        Console usage:
-
-        p = Plot()
-        p.layoutProperties()  #all the kwargs arguments
-        print(p.plot_layout) # returns the dictionary with all the values
-
-
-        {'title': 'Plot Title', 'legend': True, ..... }
-        '''
-
-        for k, v in kwargs.items():
-            self.plot_layout[k] = v
-
-        return self.plot_layout
-
-    def buildLayout(self, *args, **kwargs):
+    def buildLayout(self):
         '''
         build the final layout calling the go.Layout plotly method
 
@@ -288,7 +256,7 @@ class Plot(object):
         '''
 
         # retieve the plot_type from the kwargs and assign it to the variable
-        plot_type = kwargs['plot_type']
+        # plot_type = kwargs['plot_type']
 
         # flip the variables according to the box orientation
         if self.plot_properties['box_orientation'] == 'h':
@@ -321,16 +289,16 @@ class Plot(object):
             pass
 
         # update layout properties depending on the plot type
-        if plot_type == 'scatter':
+        if self.plot_type == 'scatter':
             self.layout['xaxis'].update(rangeslider=self.plot_layout['range_slider'])
 
-        elif plot_type == 'bar':
+        elif self.plot_type == 'bar':
             self.layout['barmode'] = self.plot_layout['bar_mode']
 
-        elif plot_type == 'histogram':
+        elif self.plot_type == 'histogram':
             self.layout['barmode'] = self.plot_layout['bar_mode']
 
-        elif plot_type == 'pie':
+        elif self.plot_type == 'pie':
             self.layout['xaxis'].update(title=''),
             self.layout['xaxis'].update(showgrid=False),
             self.layout['xaxis'].update(zeroline=False),
@@ -344,7 +312,7 @@ class Plot(object):
             self.layout['yaxis'].update(autotick=False),
             self.layout['yaxis'].update(showticklabels=False)
 
-        elif plot_type == 'ternary':
+        elif self.plot_type == 'ternary':
             self.layout['xaxis'].update(title=''),
             self.layout['xaxis'].update(showgrid=False),
             self.layout['xaxis'].update(zeroline=False),

--- a/ui/data_plotly_dialog_base.ui
+++ b/ui/data_plotly_dialog_base.ui
@@ -472,7 +472,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>362</width>
+                <width>819</width>
                 <height>563</height>
                </rect>
               </property>
@@ -687,6 +687,31 @@
            </item>
           </layout>
          </widget>
+        </widget>
+       </item>
+       <item row="4" column="2">
+        <widget class="QPushButton" name="update_btn">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Update Plot</string>
+         </property>
+         <property name="checkable">
+          <bool>false</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+         <property name="autoDefault">
+          <bool>true</bool>
+         </property>
+         <property name="default">
+          <bool>false</bool>
+         </property>
+         <property name="flat">
+          <bool>false</bool>
+         </property>
         </widget>
        </item>
       </layout>


### PR DESCRIPTION
This PR implements many different stuff:

* adds a method to call the DataPlotly dialog with a given dictionary, that is, allows the user to use DataPlotly API
* refactoring some code in `data_plotly_plot` by getting rid of some methods and refactoring the `data_ploty_dialog` to implement them
* adds the `Update Plot` button allowing the user to update the current plot (avoiding creating a new plot from scratch). If only a single plot is drawn, then the method works exactly as the `Create Plot` button, but if many plots are in the same canvas, it allows to update the last plot (only the last plot at the moment). It has been designed for a future standalone calling of DataPlotly giving the chance to update the plot with all the other customizations not available in the standalone application