### PR TITLE
Hide plot toolbar from print layout

### DIFF
--- a/DataPlotly/core/plot_factory.py
+++ b/DataPlotly/core/plot_factory.py
@@ -10,7 +10,6 @@ the Free Software Foundation; either version 2 of the License, or
 
 import tempfile
 import os
-import platform
 import re
 import plotly
 import plotly.graph_objs as go

--- a/DataPlotly/layouts/plot_layout_item.py
+++ b/DataPlotly/layouts/plot_layout_item.py
@@ -106,7 +106,7 @@ class PlotLayoutItem(QgsLayoutItem):
 
     def create_plot(self):
         factory = PlotFactory(self.plot_settings)
-        config = { 'displayModeBar': False, 'staticPlot': True }
+        config = {'displayModeBar': False, 'staticPlot': True}
         return factory.build_html(config)
 
     def load_content(self):
@@ -134,8 +134,6 @@ class PlotLayoutItem(QgsLayoutItem):
         super().refresh()
         self.html_loaded = False
         self.invalidateCache()
-
-
 
 
 class PlotLayoutItemMetadata(QgsLayoutItemAbstractMetadata):


### PR DESCRIPTION
Small edit to the function that creates the html: additional parameter needed to customize the plot(ly) toolbar