### PR TITLE
Fix #142 Take colorscale from different combobox depending on plot type

### DIFF
--- a/DataPlotly/gui/plot_settings_widget.py
+++ b/DataPlotly/gui/plot_settings_widget.py
@@ -635,6 +635,21 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
         self.color_scale_combo.addItem(self.tr('RedOrangeYellow'), 'YIOrRd')
         self.color_scale_combo.addItem(self.tr('DeepblueBlueWhite'), 'YIGnBu')
         self.color_scale_combo.addItem(self.tr('BlueWhitePurple'), 'Picnic')
+        
+        self.color_scale_data_defined_in.clear()
+        self.color_scale_data_defined_in.addItem(self.tr('Grey Scale'), 'Greys')
+        self.color_scale_data_defined_in.addItem(self.tr('Green Scale'), 'Greens')
+        self.color_scale_data_defined_in.addItem(self.tr('Fire Scale'), 'Hot')
+        self.color_scale_data_defined_in.addItem(self.tr('BlueYellowRed'), 'Portland')
+        self.color_scale_data_defined_in.addItem(self.tr('BlueGreenRed'), 'Jet')
+        self.color_scale_data_defined_in.addItem(self.tr('BlueToRed'), 'RdBu')
+        self.color_scale_data_defined_in.addItem(self.tr('BlueToRed Soft'), 'Bluered')
+        self.color_scale_data_defined_in.addItem(self.tr('BlackRedYellowBlue'), 'Blackbody')
+        self.color_scale_data_defined_in.addItem(self.tr('Terrain'), 'Earth')
+        self.color_scale_data_defined_in.addItem(self.tr('Electric Scale'), 'Electric')
+        self.color_scale_data_defined_in.addItem(self.tr('RedOrangeYellow'), 'YIOrRd')
+        self.color_scale_data_defined_in.addItem(self.tr('DeepblueBlueWhite'), 'YIGnBu')
+        self.color_scale_data_defined_in.addItem(self.tr('BlueWhitePurple'), 'Picnic')
 
         # according to the plot type, change the label names
 
@@ -868,7 +883,7 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
                            'y_name': self.y_combo.currentText(),
                            'z_name': self.z_combo.currentText(),
                            'in_color': self.in_color,
-                           'colorscale_in': self.color_scale_combo.currentData(),
+                           'colorscale_in': self.color_scale_data_defined_in.currentData() if self.ptype in self.widgetType[self.color_scale_data_defined_in] else self.color_scale_combo.currentData(),
                            'show_colorscale_legend': color_scale_visible,
                            'invert_color_scale': self.color_scale_data_defined_in_invert_check.isChecked(),
                            'out_color': hex_to_rgb(self.out_color_combo),
@@ -884,7 +899,7 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
                            'name': self.legend_title.text(),
                            'normalization': self.hist_norm_combo.currentData(),
                            'cont_type': self.contour_type[self.contour_type_combo.currentText()],
-                           'color_scale': self.color_scale_combo.currentData(),
+                           'color_scale': self.color_scale_data_defined_in.currentData() if self.ptype in self.widgetType[self.color_scale_data_defined_in] else self.color_scale_combo.currentData(),
                            'show_lines': self.show_lines_check.isChecked(),
                            'cumulative': self.cumulative_hist_check.isChecked(),
                            'invert_hist': 'decreasing' if self.invert_hist_check.isChecked() else 'increasing',


### PR DESCRIPTION
There are two comboboxes for colorscales, one that is used for scatter, bar and ternary plots, and one that is used for contour and 2D histogram plots. When setting the plot configuration, the colorscale has to be taken from the correct combobox.