### PR TITLE
Fix boxplot if not X is set

### DIFF
--- a/DataPlotly/core/plot_types/box.py
+++ b/DataPlotly/core/plot_types/box.py
@@ -43,7 +43,7 @@ class BoxPlotFactory(PlotType):
             y = settings.y
 
         return [graph_objs.Box(
-            x=x,
+            x=x if x else None,
             y=y,
             name=settings.properties['name'],
             customdata=settings.properties['custom'],

--- a/DataPlotly/core/plot_types/box.py
+++ b/DataPlotly/core/plot_types/box.py
@@ -43,7 +43,7 @@ class BoxPlotFactory(PlotType):
             y = settings.y
 
         return [graph_objs.Box(
-            x=x if x else None,
+            x=x or None,
             y=y,
             name=settings.properties['name'],
             customdata=settings.properties['custom'],


### PR DESCRIPTION
fix #174 because if no X (optional) field is chosen an empty list is passed while we need a `None` value to correct render the plot