### PR TITLE
Add "isoformat" function to QDate and QDateTime classes 

### DIFF
--- a/DataPlotly/core/plot_factory.py
+++ b/DataPlotly/core/plot_factory.py
@@ -32,7 +32,12 @@ from qgis.core import (
 from qgis.PyQt.QtCore import (
     QUrl,
     QObject,
-    pyqtSignal
+    pyqtSignal,
+    QDate,
+    QDateTime
+)
+from qgis.PyQt.Qt import (
+    Qt
 )
 from qgis.PyQt.QtGui import QColor
 from DataPlotly.core.plot_settings import PlotSettings
@@ -79,6 +84,10 @@ class PlotFactory(QObject):  # pylint:disable=too-many-instance-attributes
     }
 
     plot_built = pyqtSignal()
+
+    # Add function to QDate and QDateTime classes that the PlotlyJSONEncoder expects from date objects
+    QDate.isoformat = lambda d: d.toString(Qt.ISODate)
+    QDateTime.isoformat = lambda d: d.toString(Qt.ISODate)
 
     def __init__(self, settings: PlotSettings = None, context_generator: QgsExpressionContextGenerator = None,
                  visible_region: QgsReferencedRectangle = None, polygon_filter: FilterRegion = None):

--- a/DataPlotly/core/plot_factory.py
+++ b/DataPlotly/core/plot_factory.py
@@ -86,8 +86,10 @@ class PlotFactory(QObject):  # pylint:disable=too-many-instance-attributes
     plot_built = pyqtSignal()
 
     # Add function to QDate and QDateTime classes that the PlotlyJSONEncoder expects from date objects
-    QDate.isoformat = lambda d: d.toString(Qt.ISODate)
-    QDateTime.isoformat = lambda d: d.toString(Qt.ISODate)
+    if not hasattr(QDate, 'isoformat'):
+        QDate.isoformat = lambda d: d.toString(Qt.ISODate)
+    if not hasattr(QDateTime, 'isoformat'):
+        QDateTime.isoformat = lambda d: d.toString(Qt.ISODate)
 
     def __init__(self, settings: PlotSettings = None, context_generator: QgsExpressionContextGenerator = None,
                  visible_region: QgsReferencedRectangle = None, polygon_filter: FilterRegion = None):

--- a/DataPlotly/test/test_plot_factory.py
+++ b/DataPlotly/test/test_plot_factory.py
@@ -644,7 +644,7 @@ class DataPlotlyFactory(unittest.TestCase):
 
         # no source layer, fixed values must be used
         settings.source_layer_id = ''
-        settings.x = [QDate(2020,1,1), QDate(2020,2,1), QDate(2020,3,1)]
+        settings.x = [QDate(2020, 1, 1), QDate(2020, 2, 1), QDate(2020, 3, 1)]
         settings.y = [4, 5, 6]
         factory = PlotFactory(settings)
 
@@ -658,7 +658,7 @@ class DataPlotlyFactory(unittest.TestCase):
         self.assertEqual(plot_dictionary['x'], ["2020-01-01", "2020-02-01", "2020-03-01"])
         self.assertEqual(plot_dictionary['y'], [4, 5, 6])
 
-        settings.x = [QDateTime(2020,1,1,11,21), QDateTime(2020,2,1,0,15), QDateTime(2020,3,1,17,23,11)]
+        settings.x = [QDateTime(2020, 1, 1, 11, 21), QDateTime(2020, 2, 1, 0, 15), QDateTime(2020, 3, 1, 17, 23, 11)]
         settings.y = [4, 5, 6]
         factory = PlotFactory(settings)
 
@@ -669,7 +669,7 @@ class DataPlotlyFactory(unittest.TestCase):
         match = re.search(r'\[.*\]', plot_html)
         plot_dictionary = json.loads(match.group(0))[0]
 
-        self.assertEqual(plot_dictionary['x'], ["2020-01-01 11:21:00", "2020-02-01 00:15:00", "2020-03-01 17:23:11"])
+        self.assertEqual(plot_dictionary['x'], ["2020-01-01T11:21:00", "2020-02-01T00:15:00", "2020-03-01T17:23:11"])
         self.assertEqual(plot_dictionary['y'], [4, 5, 6])
 
 


### PR DESCRIPTION
... so Plotly does not stumble over dates.  Fixes #122

Plotly uses its own JSON encoder, which currently cannot handle QDate or QDateTime objects. The JSON encoder [expects date objects to have an `isoformat` function](https://github.com/plotly/plotly.py/blob/master/packages/python/plotly/_plotly_utils/utils.py#L175) for converting dates to strings. This pull request adds such a function.

This approach avoids having to check and convert data types on the DataPlotly side.