### PR TITLE
[Feature] additional labeling for scatter and bar plots

### DIFF
--- a/DataPlotly/core/plot_settings.py
+++ b/DataPlotly/core/plot_settings.py
@@ -69,6 +69,7 @@ class PlotSettings:  # pylint: disable=too-many-instance-attributes
             'custom': None,
             'hover_text': None,
             'additional_hover_text': None,
+            'hover_label_text': None,
             'x_name': '',
             'y_name': '',
             'z_name': '',

--- a/DataPlotly/core/plot_types/bar_plot.py
+++ b/DataPlotly/core/plot_types/bar_plot.py
@@ -48,6 +48,9 @@ class BarPlotFactory(PlotType):
         return [graph_objs.Bar(
             x=x,
             y=y,
+            text=settings.additional_hover_text,
+            textposition=settings.properties['hover_label_position'],
+            # textposition='auto',
             name=settings.data_defined_legend_title if settings.data_defined_legend_title != '' else settings.properties['name'],
             ids=featureBox,
             customdata=settings.properties['custom'],

--- a/DataPlotly/core/plot_types/scatter.py
+++ b/DataPlotly/core/plot_types/scatter.py
@@ -33,11 +33,16 @@ class ScatterPlotFactory(PlotType):
 
     @staticmethod
     def create_trace(settings):
+
+        if settings.properties['hover_label_text'] is not None:
+            mode = settings.properties['marker'] + \
+                settings.properties['hover_label_text']
+        else:
+            mode = settings.properties['marker']
         return [graph_objs.Scatter(
             x=settings.x,
             y=settings.y,
-            mode=settings.properties['marker'] +
-                settings.properties['hover_label_text'],
+            mode=mode,
             textposition="top center",
             name=settings.data_defined_legend_title if settings.data_defined_legend_title != '' else settings.properties['name'],
             ids=settings.feature_ids,

--- a/DataPlotly/core/plot_types/scatter.py
+++ b/DataPlotly/core/plot_types/scatter.py
@@ -36,7 +36,9 @@ class ScatterPlotFactory(PlotType):
         return [graph_objs.Scatter(
             x=settings.x,
             y=settings.y,
-            mode=settings.properties['marker'],
+            mode=settings.properties['marker'] +
+                settings.properties['hover_label_text'],
+            textposition="top center",
             name=settings.data_defined_legend_title if settings.data_defined_legend_title != '' else settings.properties['name'],
             ids=settings.feature_ids,
             customdata=settings.properties['custom'],

--- a/DataPlotly/gui/plot_settings_widget.py
+++ b/DataPlotly/gui/plot_settings_widget.py
@@ -762,7 +762,8 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
             self.size_defined_button: ['scatter', 'ternary'],
             self.marker_type_lab: ['scatter', 'polar'],
             self.marker_type_combo: ['scatter', 'polar'],
-            self.opacity_widget: ['scatter', 'bar', 'box', 'histogram', 'polar', 'ternary', 'violin'],
+            self.alpha_lab: ['scatter', 'bar', 'box', 'histogram', 'polar', 'ternary', 'violin', 'contour'],
+            self.opacity_widget: ['scatter', 'bar', 'box', 'histogram', 'polar', 'ternary', 'violin', 'contour'],
             self.mGroupBox_2: ['scatter', 'bar', 'box', 'histogram', 'polar', 'ternary', 'contour', '2dhistogram',
                                'violin'],
             self.bar_mode_lab: ['bar', 'histogram'],
@@ -971,8 +972,8 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
                 'color_scale_data_defined_in_invert_check'] = self.color_scale_data_defined_in_invert_check.isChecked()
             if self.ptype in self.widgetType[self.color_scale_data_defined_in]:
                 plot_properties['color_scale'] = self.color_scale_data_defined_in.currentData()
-            else:
-                plot_properties['color_scale'] = self.color_scale_combo.currentData()
+        else:
+            plot_properties['color_scale'] = self.color_scale_combo.currentData()
 
         # add widgets properties to the dictionary
 

--- a/DataPlotly/gui/plot_settings_widget.py
+++ b/DataPlotly/gui/plot_settings_widget.py
@@ -726,6 +726,12 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
         self.info_combo.addItem(self.tr('Y Values'), 'y')
         self.info_combo.addItem(self.tr('No Data'), 'none')
 
+        # label text position choice
+        self.combo_text_position.clear()
+        self.combo_text_position.addItem(self.tr('Automatic'), 'auto')
+        self.combo_text_position.addItem(self.tr('Inside bar'), 'inside')
+        self.combo_text_position.addItem(self.tr('Outside bar'), 'outside')
+
         # Violin side
         self.violinSideCombo.clear()
         self.violinSideCombo.addItem(self.tr('Both Sides'), 'both')
@@ -820,8 +826,11 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
             self.range_slider_combo: ['scatter'],
             self.hist_norm_label: ['histogram'],
             self.hist_norm_combo: ['histogram'],
-            self.additional_info_label: ['scatter', 'ternary'],
-            self.additional_info_combo: ['scatter', 'ternary'],
+            self.additional_info_label: ['scatter', 'ternary', 'bar'],
+            self.additional_info_combo: ['scatter', 'ternary', 'bar'],
+            self.hover_as_text_check: ['scatter'],
+            self.label_text_position: ['bar'],
+            self.combo_text_position: ['bar'],
             self.cumulative_hist_check: ['histogram'],
             self.invert_hist_check: ['histogram'],
             self.bins_check: ['histogram'],
@@ -928,6 +937,8 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
         # dictionary of all the plot properties
         plot_properties = {'custom': [self.x_combo.currentText()],
                            'hover_text': self.info_combo.currentData(),
+                           'hover_label_text': '+text' if self.hover_as_text_check.isChecked() else '',
+                           'hover_label_position': self.combo_text_position.currentData(),
                            'x_name': self.x_combo.currentText(),
                            'y_name': self.y_combo.currentText(),
                            'z_name': self.z_combo.currentText(),

--- a/DataPlotly/processing/dataplotly_algorithms.py
+++ b/DataPlotly/processing/dataplotly_algorithms.py
@@ -37,17 +37,17 @@ from qgis.core import (
     QgsProcessingOutputHtml,
     QgsProcessingOutputFile,
     QgsSettings,
-    QgsFeatureRequest
+    QgsFeatureRequest,
+    QgsProcessingAlgorithm
 )
 
 from qgis.PyQt.QtCore import QCoreApplication
 
-from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 from DataPlotly.core.plot_factory import PlotFactory
 from DataPlotly.core.plot_settings import PlotSettings
 
 
-class DataPlotlyProcessingPlot(QgisAlgorithm):
+class DataPlotlyProcessingPlot(QgsProcessingAlgorithm):
     """
     Create a simple plot with DataPlotly plugin
     """

--- a/DataPlotly/test/test_data_plotly_dialog.py
+++ b/DataPlotly/test/test_data_plotly_dialog.py
@@ -63,7 +63,7 @@ class DataPlotlyDialogTest(unittest.TestCase):
         self.assertEqual(dialog.get_settings().plot_type, settings.plot_type)
         for k in settings.properties.keys():
             if k in ['x', 'y', 'z', 'additional_hover_text', 'featureIds', 'featureBox', 'custom',
-                     'marker_size']:
+                     'marker_size', 'hover_text', 'hover_label_text']:
                 continue
 
             self.assertEqual(dialog.get_settings().properties[k], settings.properties[k])

--- a/DataPlotly/test/test_qgis_environment.py
+++ b/DataPlotly/test/test_qgis_environment.py
@@ -12,11 +12,9 @@ __date__ = '20/01/2011'
 __copyright__ = ('Copyright 2012, Australia Indonesia Facility for '
                  'Disaster Reduction')
 
-import os
 import unittest
 from qgis.core import (QgsProviderRegistry,
-                       QgsCoordinateReferenceSystem,
-                       QgsRasterLayer)
+                       QgsCoordinateReferenceSystem)
 from .utilities import get_qgis_app
 
 
@@ -46,13 +44,6 @@ class QGISTest(unittest.TestCase):
         crs.createFromWkt(wkt)
         auth_id = crs.authid()
         expected_auth_id = 'EPSG:4326'
-        self.assertEqual(auth_id, expected_auth_id)
-
-        # now test for a loaded layer
-        path = os.path.join(os.path.dirname(__file__), 'tenbytenraster.asc')
-        title = 'TestRaster'
-        layer = QgsRasterLayer(path, title)
-        auth_id = layer.crs().authid()
         self.assertEqual(auth_id, expected_auth_id)
 
 

--- a/DataPlotly/ui/dataplotly_dockwidget_base.ui
+++ b/DataPlotly/ui/dataplotly_dockwidget_base.ui
@@ -204,8 +204,8 @@ QListWidget::item::selected {
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>405</width>
-                  <height>504</height>
+                  <width>531</width>
+                  <height>653</height>
                  </rect>
                 </property>
                 <layout class="QGridLayout" name="gridLayout_9">
@@ -599,8 +599,8 @@ QListWidget::item::selected {
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>384</width>
-                  <height>682</height>
+                  <width>424</width>
+                  <height>979</height>
                  </rect>
                 </property>
                 <layout class="QGridLayout" name="gridLayout_25" columnstretch="0,0,1,0">
@@ -616,6 +616,59 @@ QListWidget::item::selected {
                  <property name="bottomMargin">
                   <number>0</number>
                  </property>
+                 <item row="3" column="1" colspan="2">
+                  <widget class="QLineEdit" name="plot_title_line"/>
+                 </item>
+                 <item row="28" column="1" colspan="3">
+                  <layout class="QHBoxLayout" name="horizontalLayout_8" stretch="1,1">
+                   <item>
+                    <widget class="QgsSpinBox" name="bins_value">
+                     <property name="enabled">
+                      <bool>false</bool>
+                     </property>
+                     <property name="maximum">
+                      <number>1000</number>
+                     </property>
+                     <property name="value">
+                      <number>10</number>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <spacer name="horizontalSpacer_4">
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>40</width>
+                       <height>20</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                  </layout>
+                 </item>
+                 <item row="21" column="1" colspan="3">
+                  <widget class="QComboBox" name="box_statistic_combo"/>
+                 </item>
+                 <item row="6" column="3">
+                  <widget class="QgsPropertyOverrideButton" name="y_axis_title_defined_button">
+                   <property name="text">
+                    <string>...</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="10" column="0">
+                  <widget class="QLabel" name="additional_info_label">
+                   <property name="text">
+                    <string>Additional hover label</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="6" column="1" rowspan="2" colspan="2">
+                  <widget class="QLineEdit" name="y_axis_title"/>
+                 </item>
                  <item row="2" column="0" colspan="4">
                   <layout class="QHBoxLayout" name="horizontalLayout_6">
                    <item>
@@ -644,34 +697,24 @@ QListWidget::item::selected {
                    </item>
                   </layout>
                  </item>
-                 <item row="5" column="1" colspan="2">
-                  <widget class="QLineEdit" name="x_axis_title"/>
+                 <item row="3" column="0">
+                  <widget class="QLabel" name="plot_title_lab">
+                   <property name="text">
+                    <string>Plot title</string>
+                   </property>
+                  </widget>
                  </item>
-                 <item row="25" column="0" colspan="4">
-                  <layout class="QHBoxLayout" name="horizontalLayout_7">
-                   <item>
-                    <widget class="QCheckBox" name="invert_hist_check">
-                     <property name="enabled">
-                      <bool>true</bool>
-                     </property>
-                     <property name="text">
-                      <string>Invert histogram direction</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QCheckBox" name="cumulative_hist_check">
-                     <property name="enabled">
-                      <bool>true</bool>
-                     </property>
-                     <property name="text">
-                      <string>Cumulative histogram</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
+                 <item row="22" column="0">
+                  <widget class="QLabel" name="outliers_label">
+                   <property name="text">
+                    <string>Outliers</string>
+                   </property>
+                  </widget>
                  </item>
-                 <item row="29" column="0" colspan="3">
+                 <item row="22" column="1" colspan="3">
+                  <widget class="QComboBox" name="outliers_combo"/>
+                 </item>
+                 <item row="30" column="0" colspan="3">
                   <spacer name="verticalSpacer_6">
                    <property name="orientation">
                     <enum>Qt::Vertical</enum>
@@ -684,84 +727,26 @@ QListWidget::item::selected {
                    </property>
                   </spacer>
                  </item>
-                 <item row="19" column="0">
-                  <widget class="QLabel" name="hist_norm_label">
-                   <property name="text">
-                    <string>Normalization</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="12" column="2" colspan="2">
-                  <widget class="QComboBox" name="x_axis_mode_combo"/>
-                 </item>
-                 <item row="28" column="1" colspan="3">
-                  <layout class="QHBoxLayout" name="horizontalLayout_9" stretch="1,1">
-                   <item>
-                    <widget class="QgsDoubleSpinBox" name="bar_gap">
-                     <property name="maximum">
-                      <double>1.000000000000000</double>
-                     </property>
-                     <property name="singleStep">
-                      <double>0.100000000000000</double>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <spacer name="horizontalSpacer_5">
-                     <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
-                     </property>
-                     <property name="sizeHint" stdset="0">
-                      <size>
-                       <width>40</width>
-                       <height>20</height>
-                      </size>
-                     </property>
-                    </spacer>
-                   </item>
-                  </layout>
-                 </item>
-                 <item row="18" column="1" colspan="3">
-                  <widget class="QComboBox" name="bar_mode_combo"/>
-                 </item>
-                 <item row="10" column="1" colspan="3">
-                  <widget class="QgsFieldExpressionWidget" name="additional_info_combo" native="true"/>
-                 </item>
-                 <item row="9" column="0">
-                  <widget class="QLabel" name="info_label">
-                   <property name="text">
-                    <string>Hover tooltip</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="18" column="0">
-                  <widget class="QLabel" name="bar_mode_lab">
-                   <property name="text">
-                    <string>Bar mode</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="20" column="0">
-                  <widget class="QLabel" name="box_statistic_label">
-                   <property name="text">
-                    <string>Show statistics</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="3" column="1" colspan="2">
-                  <widget class="QLineEdit" name="plot_title_line"/>
+                 <item row="5" column="1" colspan="2">
+                  <widget class="QLineEdit" name="x_axis_title"/>
                  </item>
                  <item row="4" column="1" colspan="2">
                   <widget class="QLineEdit" name="legend_title"/>
                  </item>
-                 <item row="8" column="0">
-                  <widget class="QLabel" name="z_axis_label">
+                 <item row="23" column="1" colspan="3">
+                  <widget class="QComboBox" name="violinSideCombo"/>
+                 </item>
+                 <item row="18" column="0">
+                  <widget class="QLabel" name="orientation_label">
                    <property name="text">
-                    <string>Z label</string>
+                    <string>Bar orientation</string>
                    </property>
                   </widget>
                  </item>
-                 <item row="14" column="0" colspan="4">
+                 <item row="10" column="1" colspan="3">
+                  <widget class="QgsFieldExpressionWidget" name="additional_info_combo" native="true"/>
+                 </item>
+                 <item row="15" column="0" colspan="4">
                   <widget class="QgsCollapsibleGroupBox" name="x_axis_bounds_check">
                    <property name="title">
                     <string>Set X Axis Bounds</string>
@@ -810,6 +795,37 @@ QListWidget::item::selected {
                    </layout>
                   </widget>
                  </item>
+                 <item row="3" column="3">
+                  <widget class="QgsPropertyOverrideButton" name="plot_title_defined_button">
+                   <property name="text">
+                    <string>...</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="26" column="0" colspan="4">
+                  <layout class="QHBoxLayout" name="horizontalLayout_7">
+                   <item>
+                    <widget class="QCheckBox" name="invert_hist_check">
+                     <property name="enabled">
+                      <bool>true</bool>
+                     </property>
+                     <property name="text">
+                      <string>Invert histogram direction</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QCheckBox" name="cumulative_hist_check">
+                     <property name="enabled">
+                      <bool>true</bool>
+                     </property>
+                     <property name="text">
+                      <string>Cumulative histogram</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </item>
                  <item row="5" column="3">
                   <widget class="QgsPropertyOverrideButton" name="x_axis_title_defined_button">
                    <property name="text">
@@ -817,60 +833,71 @@ QListWidget::item::selected {
                    </property>
                   </widget>
                  </item>
-                 <item row="28" column="0">
-                  <widget class="QLabel" name="bar_gap_label">
+                 <item row="19" column="1" colspan="3">
+                  <widget class="QComboBox" name="bar_mode_combo"/>
+                 </item>
+                 <item row="13" column="0">
+                  <widget class="QCheckBox" name="invert_x_check">
                    <property name="text">
-                    <string>Bar gap</string>
+                    <string>Invert X axis</string>
                    </property>
                   </widget>
                  </item>
-                 <item row="22" column="1" colspan="3">
-                  <widget class="QComboBox" name="violinSideCombo"/>
+                 <item row="19" column="0">
+                  <widget class="QLabel" name="bar_mode_lab">
+                   <property name="text">
+                    <string>Bar mode</string>
+                   </property>
+                  </widget>
                  </item>
-                 <item row="12" column="1">
+                 <item row="9" column="0">
+                  <widget class="QLabel" name="info_label">
+                   <property name="text">
+                    <string>Hover tooltip</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="11" column="0">
+                  <widget class="QCheckBox" name="hover_as_text_check">
+                   <property name="text">
+                    <string>Hover label as text</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="13" column="1">
                   <widget class="QLabel" name="x_axis_mode_label">
                    <property name="text">
                     <string>X axis mode</string>
                    </property>
                   </widget>
                  </item>
-                 <item row="8" column="1" colspan="2">
-                  <widget class="QLineEdit" name="z_axis_title"/>
-                 </item>
-                 <item row="13" column="1">
-                  <widget class="QLabel" name="y_axis_mode_label">
+                 <item row="21" column="0">
+                  <widget class="QLabel" name="box_statistic_label">
                    <property name="text">
-                    <string>Y axis mode</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="6" column="1" rowspan="2" colspan="2">
-                  <widget class="QLineEdit" name="y_axis_title"/>
-                 </item>
-                 <item row="24" column="0" colspan="4">
-                  <widget class="QCheckBox" name="showMeanCheck">
-                   <property name="text">
-                    <string>Show mean line</string>
-                   </property>
-                   <property name="checked">
-                    <bool>true</bool>
+                    <string>Show statistics</string>
                    </property>
                   </widget>
                  </item>
                  <item row="9" column="1" colspan="3">
                   <widget class="QComboBox" name="info_combo"/>
                  </item>
-                 <item row="13" column="0">
-                  <widget class="QCheckBox" name="invert_y_check">
-                   <property name="text">
-                    <string>Invert Y axis</string>
-                   </property>
-                  </widget>
+                 <item row="14" column="2" colspan="2">
+                  <widget class="QComboBox" name="y_axis_mode_combo"/>
                  </item>
                  <item row="4" column="0">
                   <widget class="QLabel" name="legend_label">
                    <property name="text">
                     <string>Legend title</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="25" column="0" colspan="4">
+                  <widget class="QCheckBox" name="showMeanCheck">
+                   <property name="text">
+                    <string>Show mean line</string>
+                   </property>
+                   <property name="checked">
+                    <bool>true</bool>
                    </property>
                   </widget>
                  </item>
@@ -881,24 +908,17 @@ QListWidget::item::selected {
                    </property>
                   </widget>
                  </item>
-                 <item row="17" column="0">
-                  <widget class="QLabel" name="orientation_label">
+                 <item row="29" column="0">
+                  <widget class="QLabel" name="bar_gap_label">
                    <property name="text">
-                    <string>Bar orientation</string>
+                    <string>Bar gap</string>
                    </property>
                   </widget>
                  </item>
-                 <item row="8" column="3">
-                  <widget class="QgsPropertyOverrideButton" name="z_axis_title_defined_button">
+                 <item row="14" column="0">
+                  <widget class="QCheckBox" name="invert_y_check">
                    <property name="text">
-                    <string>...</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="21" column="0">
-                  <widget class="QLabel" name="outliers_label">
-                   <property name="text">
-                    <string>Outliers</string>
+                    <string>Invert Y axis</string>
                    </property>
                   </widget>
                  </item>
@@ -909,83 +929,6 @@ QListWidget::item::selected {
                    </property>
                   </widget>
                  </item>
-                 <item row="10" column="0">
-                  <widget class="QLabel" name="additional_info_label">
-                   <property name="text">
-                    <string>Additional hover label</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="27" column="0">
-                  <widget class="QCheckBox" name="bins_check">
-                   <property name="text">
-                    <string>Manual bin size</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="12" column="0">
-                  <widget class="QCheckBox" name="invert_x_check">
-                   <property name="text">
-                    <string>Invert X axis</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="3" column="3">
-                  <widget class="QgsPropertyOverrideButton" name="plot_title_defined_button">
-                   <property name="text">
-                    <string>...</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="27" column="1" colspan="3">
-                  <layout class="QHBoxLayout" name="horizontalLayout_8" stretch="1,1">
-                   <item>
-                    <widget class="QgsSpinBox" name="bins_value">
-                     <property name="enabled">
-                      <bool>false</bool>
-                     </property>
-                     <property name="maximum">
-                      <number>1000</number>
-                     </property>
-                     <property name="value">
-                      <number>10</number>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <spacer name="horizontalSpacer_4">
-                     <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
-                     </property>
-                     <property name="sizeHint" stdset="0">
-                      <size>
-                       <width>40</width>
-                       <height>20</height>
-                      </size>
-                     </property>
-                    </spacer>
-                   </item>
-                  </layout>
-                 </item>
-                 <item row="20" column="1" colspan="3">
-                  <widget class="QComboBox" name="box_statistic_combo"/>
-                 </item>
-                 <item row="19" column="1" colspan="3">
-                  <widget class="QComboBox" name="hist_norm_combo"/>
-                 </item>
-                 <item row="17" column="1" colspan="3">
-                  <widget class="QComboBox" name="orientation_combo"/>
-                 </item>
-                 <item row="3" column="0">
-                  <widget class="QLabel" name="plot_title_lab">
-                   <property name="text">
-                    <string>Plot title</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="13" column="2" colspan="2">
-                  <widget class="QComboBox" name="y_axis_mode_combo"/>
-                 </item>
                  <item row="6" column="0" rowspan="2">
                   <widget class="QLabel" name="y_axis_label">
                    <property name="text">
@@ -993,17 +936,7 @@ QListWidget::item::selected {
                    </property>
                   </widget>
                  </item>
-                 <item row="22" column="0">
-                  <widget class="QLabel" name="violinSideLabel">
-                   <property name="text">
-                    <string>Violin side</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="21" column="1" colspan="3">
-                  <widget class="QComboBox" name="outliers_combo"/>
-                 </item>
-                 <item row="15" column="0" colspan="4">
+                 <item row="16" column="0" colspan="4">
                   <widget class="QgsCollapsibleGroupBox" name="y_axis_bounds_check">
                    <property name="title">
                     <string>Set Y Axis Bounds</string>
@@ -1052,14 +985,81 @@ QListWidget::item::selected {
                    </layout>
                   </widget>
                  </item>
-                 <item row="6" column="3">
-                  <widget class="QgsPropertyOverrideButton" name="y_axis_title_defined_button">
+                 <item row="14" column="1">
+                  <widget class="QLabel" name="y_axis_mode_label">
+                   <property name="text">
+                    <string>Y axis mode</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="8" column="1" colspan="2">
+                  <widget class="QLineEdit" name="z_axis_title"/>
+                 </item>
+                 <item row="28" column="0">
+                  <widget class="QCheckBox" name="bins_check">
+                   <property name="text">
+                    <string>Manual bin size</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="8" column="0">
+                  <widget class="QLabel" name="z_axis_label">
+                   <property name="text">
+                    <string>Z label</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="23" column="0">
+                  <widget class="QLabel" name="violinSideLabel">
+                   <property name="text">
+                    <string>Violin side</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="8" column="3">
+                  <widget class="QgsPropertyOverrideButton" name="z_axis_title_defined_button">
                    <property name="text">
                     <string>...</string>
                    </property>
                   </widget>
                  </item>
-                 <item row="23" column="0" colspan="4">
+                 <item row="18" column="1" colspan="3">
+                  <widget class="QComboBox" name="orientation_combo"/>
+                 </item>
+                 <item row="20" column="1" colspan="3">
+                  <widget class="QComboBox" name="hist_norm_combo"/>
+                 </item>
+                 <item row="13" column="2" colspan="2">
+                  <widget class="QComboBox" name="x_axis_mode_combo"/>
+                 </item>
+                 <item row="29" column="1" colspan="3">
+                  <layout class="QHBoxLayout" name="horizontalLayout_9" stretch="1,1">
+                   <item>
+                    <widget class="QgsDoubleSpinBox" name="bar_gap">
+                     <property name="maximum">
+                      <double>1.000000000000000</double>
+                     </property>
+                     <property name="singleStep">
+                      <double>0.100000000000000</double>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <spacer name="horizontalSpacer_5">
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>40</width>
+                       <height>20</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                  </layout>
+                 </item>
+                 <item row="24" column="0" colspan="4">
                   <widget class="QCheckBox" name="violinBox">
                    <property name="toolTip">
                     <string>If checked, box plots will be overlaid on top of violin plots</string>
@@ -1071,6 +1071,23 @@ QListWidget::item::selected {
                     <bool>true</bool>
                    </property>
                   </widget>
+                 </item>
+                 <item row="20" column="0">
+                  <widget class="QLabel" name="hist_norm_label">
+                   <property name="text">
+                    <string>Normalization</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="12" column="0">
+                  <widget class="QLabel" name="label_text_position">
+                   <property name="text">
+                    <string>Label text position</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="12" column="1" colspan="3">
+                  <widget class="QComboBox" name="combo_text_position"/>
                  </item>
                 </layout>
                </widget>


### PR DESCRIPTION
A missing feature. The additional hover label can be set as *real* label to be shown ON the plot for both scatter and bar (other plots?).

**Scatter**

![immagine](https://user-images.githubusercontent.com/2884884/76227243-4d620880-621f-11ea-9ce1-c997bdef9c91.png)

![immagine](https://user-images.githubusercontent.com/2884884/76227209-3e7b5600-621f-11ea-9106-43b4e78d9c60.png)

**Bar**

![immagine](https://user-images.githubusercontent.com/2884884/76227498-b0539f80-621f-11ea-8860-5d3fa1ca013a.png)


