### PR TITLE
Fix wrong bar plot with categories

### DIFF
--- a/DataPlotly/core/plot_types/bar_plot.py
+++ b/DataPlotly/core/plot_types/bar_plot.py
@@ -51,7 +51,7 @@ class BarPlotFactory(PlotType):
             text=settings.additional_hover_text,
             textposition=settings.properties.get('hover_label_position'),
             name=settings.data_defined_legend_title if settings.data_defined_legend_title != '' else settings.properties['name'],
-            ids=featureBox,
+            ids=settings.feature_ids,
             customdata=settings.properties['custom'],
             orientation=settings.properties['box_orientation'],
             marker={'color': settings.data_defined_colors if settings.data_defined_colors else settings.properties['in_color'],


### PR DESCRIPTION
fixes #214 

we don't really need `ids` as a parameter, but it could become useful if we introduce animations. See https://plotly.com/python/reference/#bar-ids for a reference (each plot type has its own `ids`)