### PR TITLE
More coherent behavior of point and line color in scatter plot

### DIFF
--- a/DataPlotly/core/plot_types/scatter.py
+++ b/DataPlotly/core/plot_types/scatter.py
@@ -61,8 +61,9 @@ class ScatterPlotFactory(PlotType):
                     'line': {'color': settings.data_defined_stroke_colors if settings.data_defined_stroke_colors else settings.properties['out_color'],
                              'width': settings.data_defined_stroke_widths if settings.data_defined_stroke_widths else settings.properties['marker_width']}
                     },
-            line={'width': settings.properties['marker_width'],
-                  'dash': settings.properties['line_dash']},
+            line={'color': settings.data_defined_stroke_colors if settings.data_defined_stroke_colors else settings.properties['out_color'],
+                'width': settings.properties['marker_width'],
+                'dash': settings.properties['line_dash']},
             opacity=settings.properties['opacity']
         )]
 


### PR DESCRIPTION
fix #220 

nothing special, the line color in scatter plot is taken from the `Stroke color` widget therefore it is possible to show points & lines with the correct colors in the plot.