### PR TITLE
Print layout small enhancements

### DIFF
--- a/DataPlotly/core/plot_factory.py
+++ b/DataPlotly/core/plot_factory.py
@@ -223,7 +223,7 @@ class PlotFactory(QObject):  # pylint:disable=too-many-instance-attributes
         stroke_colors = []
         stroke_widths = []
         for f in it:
-            if visible_geom_engine and not visible_geom_engine.intersects(f.geometry().constGet()):
+            if visible_geom_engine and not visible_geom_engine.within(f.geometry().constGet()):
                 continue
 
             self.settings.feature_ids.append(f.id())

--- a/DataPlotly/core/plot_settings.py
+++ b/DataPlotly/core/plot_settings.py
@@ -60,7 +60,7 @@ class PlotSettings:  # pylint: disable=too-many-instance-attributes
     }
 
     def __init__(self, plot_type: str = 'scatter', properties: dict = None, layout: dict = None,
-                 source_layer_id=None):
+                 source_layer_id=None, source_layer_name=None):
         # Define default plot dictionary used as a basis for plot initialization
         # prepare the default dictionary with None values
         # plot properties
@@ -176,6 +176,7 @@ class PlotSettings:  # pylint: disable=too-many-instance-attributes
         self.data_defined_y_min = None
         self.data_defined_y_max = None
         self.source_layer_id = source_layer_id
+        self.source_layer_name = source_layer_name
 
     def write_xml(self, document: QDomDocument):
         """

--- a/DataPlotly/gui/layout_item_gui.py
+++ b/DataPlotly/gui/layout_item_gui.py
@@ -92,9 +92,11 @@ class PlotLayoutItemWidget(QgsLayoutItemBaseWidget):
         self.plot_list.clear()
         for setting in self.plot_item.plot_settings:
             plot_type = setting.plot_type if setting.plot_type is not None else '(not set)'
-            legend_title = ('[' + setting.properties.get('name') + ']') \
-                if setting.properties.get('name', '') != '' else ''
-            self.plot_list.addItem(plot_type + ' ' + legend_title)
+            layer_name = ('- ' + setting.source_layer_name +
+                          ' -') if setting.source_layer_name is not None else ''
+            legend_title = ('[' + setting.properties.get('name') +
+                            ']') if setting.properties.get('name', '') != '' else ''
+            self.plot_list.addItem(f'{plot_type} {layer_name} {legend_title}')
 
         # select index within range [0, len(plot_settings)-1]
         selected_index = max(0, min(len(self.plot_item.plot_settings) - 1, selected_index))

--- a/DataPlotly/gui/plot_settings_widget.py
+++ b/DataPlotly/gui/plot_settings_widget.py
@@ -1036,7 +1036,8 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
                              'bins_check': self.bins_check.isChecked()}
 
         settings = PlotSettings(plot_type=self.ptype, properties=plot_properties, layout=layout_properties,
-                            source_layer_id=self.layer_combo.currentLayer().id() if self.layer_combo.currentLayer() else None)
+                            source_layer_id=self.layer_combo.currentLayer().id() if self.layer_combo.currentLayer() else None,
+                            source_layer_name=self.layer_combo.currentLayer().name() if self.layer_combo.currentLayer() else None)
         settings.data_defined_properties = self.data_defined_properties
         return settings
 


### PR DESCRIPTION
* I think it is useful to have the layer name together with the plot type and the variable(s) chosen:
  
  ![image](https://user-images.githubusercontent.com/2884884/82072722-6cc25980-96d8-11ea-9ec2-8f5449cc4e04.png)

* the behavior of the checkbox `Use only features inside atlas feature` was based on `intersect`, e.g.
 
  ![interesect](https://user-images.githubusercontent.com/2884884/82072822-93809000-96d8-11ea-8eb1-d61b770b3c17.png)

  I think `within` is better:
  
  ![within](https://user-images.githubusercontent.com/2884884/82072853-9f6c5200-96d8-11ea-8909-a9da7d70ea5b.png)

Opinions welcome!

