### PR TITLE
Fix "type object 'DataType' has no attribute 'DataTypeString'" error

### DIFF
--- a/DataPlotly/gui/plot_settings_widget.py
+++ b/DataPlotly/gui/plot_settings_widget.py
@@ -726,7 +726,7 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
             self.in_color_defined_button.init(
                 PlotSettings.PROPERTY_COLOR, self.data_defined_properties.property(PlotSettings.PROPERTY_COLOR),
                 QgsPropertyDefinition(
-                    'color', QgsPropertyDefinition.DataType.DataTypeString, 'Color Array',
+                    'color', QgsPropertyDefinition.DataTypeString, 'Color Array',
                     "string [<b>r,g,b,a</b>] as int 0-255 or #<b>AARRGGBB</b> as hex or <b>color</b> as color's name, "
                     "or an array of such strings"
                 ), None, False
@@ -738,7 +738,7 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
             self.in_color_defined_button.init(
                 PlotSettings.PROPERTY_COLOR, self.data_defined_properties.property(PlotSettings.PROPERTY_COLOR),
                 QgsPropertyDefinition(
-                    'color', QgsPropertyDefinition.DataType.DataTypeString, 'Color Array',
+                    'color', QgsPropertyDefinition.DataTypeString, 'Color Array',
                     "string [<b>r,g,b,a</b>] as int 0-255 or #<b>AARRGGBB</b> as hex or <b>color</b> as color's name, "
                     "or an array of such strings"
                 ), None, False


### PR DESCRIPTION
When changing the plot type to "pie", I get the following error message:

```
 'color', QgsPropertyDefinition.DataType.DataTypeString, 'Color Array',
AttributeError: type object 'DataType' has no attribute 'DataTypeString'
```
The effect of this error is that the "format help" in the expression editor for the marker color is not updated correctly.

This error is caused by an incorrect call to the `DataTypeString` constant, which is fixed in this PR