### PR TITLE
Fix reinitializing properties widget

### DIFF
--- a/DataPlotly/gui/plot_settings_widget.py
+++ b/DataPlotly/gui/plot_settings_widget.py
@@ -243,6 +243,7 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
         self.register_data_defined_button(self.stroke_defined_button, PlotSettings.PROPERTY_STROKE_WIDTH)
         self.stroke_defined_button.registerEnabledWidget(self.marker_width, natural=False)
         self.register_data_defined_button(self.in_color_defined_button, PlotSettings.PROPERTY_COLOR)
+        self.in_color_defined_button.registerEnabledWidget(self.in_color_combo, natural=False)
         self.in_color_defined_button.changed.connect(self.data_defined_color_updated)
         self.register_data_defined_button(self.out_color_defined_button, PlotSettings.PROPERTY_STROKE_COLOR)
         self.out_color_defined_button.registerEnabledWidget(self.out_color_combo, natural=False)
@@ -1065,6 +1066,9 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
         buttons = self.findChildren(QgsPropertyOverrideButton)
         for button in buttons:
             self.update_data_defined_button(button)
+
+        # trigger methods depending on data defined button properties
+        self.data_defined_color_updated()
 
         self.x_combo.setExpression(settings.properties.get('x_name', ''))
         self.y_combo.setExpression(settings.properties.get('y_name', ''))

--- a/DataPlotly/gui/plot_settings_widget.py
+++ b/DataPlotly/gui/plot_settings_widget.py
@@ -182,6 +182,7 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
         # widgets
         self.refreshWidgets()
         self.refreshWidgets2()
+        self.refreshWidgets3()
         self.plot_combo.currentIndexChanged.connect(self.refreshWidgets)
         self.plot_combo.currentIndexChanged.connect(self.helpPage)
         self.subcombo.currentIndexChanged.connect(self.refreshWidgets2)

--- a/DataPlotly/gui/plot_settings_widget.py
+++ b/DataPlotly/gui/plot_settings_widget.py
@@ -187,8 +187,6 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
         self.subcombo.currentIndexChanged.connect(self.refreshWidgets2)
         self.marker_type_combo.currentIndexChanged.connect(self.refreshWidgets3)
 
-        self.properties_group_box.collapsedStateChanged.connect(self.refreshWidgets)
-
         # fill the layer combobox with vector layers
         self.layer_combo.setFilters(QgsMapLayerProxyModel.VectorLayer)
 


### PR DESCRIPTION
Fixes #213 

This PR attempts to fix the following UI issues:

- After setting the properties in the widget, the whole widget is re-initialized, e.g. the combo box is cleared and the items are added again. Selected items like the marker type (points/lines/points+lines) are lost. I think removing the collapsedStateChanged event of the properties_group_box fixes this. I do not see a reason why we need this event.
- At widget initialization, I added the call to initialize the point and line combo boxes (refreshWidgets3 method) in order to hide the line combo box if the point marker is selected. Previously, refreshWidgets3() was only called after the marker type combo box changed.
- The in_color_combo data-defined-button had two problems. (1) It was not properly linked to the color combo box. (2) And the row containing the color scale settings, which are only visible when the data-defined button is active, was not visible after widget initialization. After deactivating and re-activating the data-defined button, this row appeared. Now, it is visible immediately.
