### PR TITLE
Double click plot in plot list to show properties

### DIFF
--- a/DataPlotly/gui/layout_item_gui.py
+++ b/DataPlotly/gui/layout_item_gui.py
@@ -77,6 +77,7 @@ class PlotLayoutItemWidget(QgsLayoutItemBaseWidget):
 
         self.plot_list = QListWidget()
         self.plot_list.setSelectionMode(QListWidget.SingleSelection)
+        self.plot_list.doubleClicked.connect(self.show_properties)
         vl.addWidget(self.plot_list)
         self.populate_plot_list()
 


### PR DESCRIPTION
UX improvement in PlotLayoutItemWidget

Add double click event for plot list to show properties of selected plot