### PR TITLE
fix deleting plot in layout stack trace

### DIFF
--- a/DataPlotly/gui/layout_item_gui.py
+++ b/DataPlotly/gui/layout_item_gui.py
@@ -218,7 +218,11 @@ class PlotLayoutItemWidget(QgsLayoutItemBaseWidget):
         self.plot_item.set_plot_settings(self.plot_list.currentRow(), self.panel.get_settings())
         self.populate_plot_list()
         self.panel = None
-        self.plot_item.update()
+        try:
+            self.plot_item.update()
+        except RuntimeError:
+            # c++ object already gone!
+            pass
 
     def linked_map_changed(self, linked_map):
         """

--- a/DataPlotly/layouts/plot_layout_item.py
+++ b/DataPlotly/layouts/plot_layout_item.py
@@ -151,7 +151,11 @@ class PlotLayoutItem(QgsLayoutItem):
             self.plot_settings[plot_id] = settings
             self.plot_settings[plot_id].layout['bg_color'] = 'rgba(0,0,0,0)'
             self.html_loaded = False
-            self.invalidateCache()
+            try:
+                self.invalidateCache()
+            except RuntimeError:
+                # c++ object already gone!
+                pass
 
     def draw(self, context):
         if not self.html_loaded:


### PR DESCRIPTION
Fix the StackTrace:

```
RuntimeError: wrapped C/C++ object of type PlotLayoutItem has been deleted 
Traceback (most recent call last):
  File "/home/matteo/.local/share/QGIS/QGIS3/profiles/matteo/python/plugins/DataPlotly/gui/layout_item_gui.py", line 218, in set_item_settings
    self.plot_item.set_plot_settings(self.plot_list.currentRow(), self.panel.get_settings())
  File "/home/matteo/.local/share/QGIS/QGIS3/profiles/matteo/python/plugins/DataPlotly/layouts/plot_layout_item.py", line 154, in set_plot_settings
    self.invalidateCache()
RuntimeError: wrapped C/C++ object of type PlotLayoutItem has been deleted
```

when a plot is added to the layout and then removed. Should be an harmless fix but a blessing is of course more than accepted :)
