### PR TITLE
Some more UI fixes

### DIFF
--- a/DataPlotly/core/plot_types/pie.py
+++ b/DataPlotly/core/plot_types/pie.py
@@ -40,6 +40,7 @@ class PieChartFactory(PlotType):
                     colors=settings.data_defined_colors if settings.data_defined_colors else [settings.properties['in_color']]
                 ),
                 name=settings.properties['custom'][0],
+                opacity=settings.properties['opacity']
             )]
 
     @staticmethod

--- a/DataPlotly/gui/plot_settings_widget.py
+++ b/DataPlotly/gui/plot_settings_widget.py
@@ -797,7 +797,7 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
             self.size_defined_button: ['scatter', 'ternary'],
             self.marker_type_lab: ['scatter', 'polar'],
             self.marker_type_combo: ['scatter', 'polar'],
-            self.alpha_lab: ['scatter', 'bar', 'box', 'histogram', 'polar', 'ternary', 'violin', 'contour'],
+            self.alpha_lab: ['scatter', 'bar', 'box', 'pie', 'histogram', 'polar', 'ternary', 'violin', 'contour'],
             self.opacity_widget: ['scatter', 'bar', 'box', 'pie', 'histogram', 'polar', 'ternary', 'violin', 'contour'],
             self.properties_group_box: ['scatter', 'bar', 'box', 'pie', 'histogram', 'polar', 'ternary', 'contour', '2dhistogram',
                                         'violin'],

--- a/DataPlotly/gui/plot_settings_widget.py
+++ b/DataPlotly/gui/plot_settings_widget.py
@@ -788,6 +788,7 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
             self.color_scale_data_defined_in_invert_check: ['bar', 'ternary'],
             self.out_color_lab: ['scatter', 'bar', 'box', 'pie', 'histogram', 'polar', 'ternary', 'violin'],
             self.out_color_combo: ['scatter', 'bar', 'box', 'pie', 'histogram', 'polar', 'ternary', 'violin'],
+            self.out_color_defined_button: ['scatter', 'bar', 'box', 'pie', 'histogram', 'polar', 'ternary', 'violin'],
             self.marker_width_lab: ['scatter', 'bar', 'box', 'histogram', 'polar', 'ternary', 'violin'],
             self.marker_width: ['scatter', 'bar', 'box', 'histogram', 'polar', 'ternary', 'violin'],
             self.stroke_defined_button: ['scatter', 'bar', 'box', 'histogram', 'polar', 'ternary', 'violin'],

--- a/DataPlotly/ui/dataplotly_dockwidget_base.ui
+++ b/DataPlotly/ui/dataplotly_dockwidget_base.ui
@@ -258,7 +258,7 @@ QListWidget::item::selected {
          <item row="0" column="0">
           <widget class="QStackedWidget" name="stackedNestedPlotWidget">
            <property name="currentIndex">
-            <number>1</number>
+            <number>0</number>
            </property>
            <widget class="QWidget" name="page">
             <layout class="QGridLayout" name="gridLayout">
@@ -321,8 +321,8 @@ QListWidget::item::selected {
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>665</width>
-                  <height>1011</height>
+                  <width>673</width>
+                  <height>989</height>
                  </rect>
                 </property>
                 <layout class="QGridLayout" name="gridLayout_9">
@@ -883,8 +883,8 @@ QListWidget::item::selected {
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>686</width>
-                  <height>742</height>
+                  <width>687</width>
+                  <height>748</height>
                  </rect>
                 </property>
                 <layout class="QGridLayout" name="gridLayout_25" columnstretch="0,0,0">

--- a/DataPlotly/ui/dataplotly_dockwidget_base.ui
+++ b/DataPlotly/ui/dataplotly_dockwidget_base.ui
@@ -322,7 +322,7 @@ QListWidget::item::selected {
                   <x>0</x>
                   <y>0</y>
                   <width>673</width>
-                  <height>989</height>
+                  <height>1018</height>
                  </rect>
                 </property>
                 <layout class="QGridLayout" name="gridLayout_9">
@@ -489,6 +489,121 @@ QListWidget::item::selected {
                     <string>Properties</string>
                    </property>
                    <layout class="QGridLayout" name="gridLayout_22">
+                    <item row="21" column="0">
+                     <widget class="QLabel" name="violinSideLabel">
+                      <property name="text">
+                       <string>Violin side</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="1" column="2">
+                     <widget class="QgsPropertyOverrideButton" name="in_color_defined_button">
+                      <property name="text">
+                       <string>...</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="16" column="0">
+                     <widget class="QLabel" name="label_text_position">
+                      <property name="text">
+                       <string>Label text position</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="10" column="0">
+                     <widget class="QLabel" name="color_scale_label">
+                      <property name="text">
+                       <string>Color scale</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="25" column="1" colspan="5">
+                     <widget class="QgsSpinBox" name="bins_value">
+                      <property name="enabled">
+                       <bool>false</bool>
+                      </property>
+                      <property name="maximum">
+                       <number>1000</number>
+                      </property>
+                      <property name="value">
+                       <number>10</number>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="4" column="2">
+                     <widget class="QgsPropertyOverrideButton" name="out_color_defined_button">
+                      <property name="text">
+                       <string>...</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="0" column="1" colspan="4">
+                     <widget class="QLineEdit" name="legend_title"/>
+                    </item>
+                    <item row="15" column="0">
+                     <widget class="QCheckBox" name="hover_as_text_check">
+                      <property name="text">
+                       <string>Hover label as text</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="11" column="1" colspan="5">
+                     <widget class="QgsOpacityWidget" name="opacity_widget">
+                      <property name="focusPolicy">
+                       <enum>Qt::StrongFocus</enum>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="21" column="1" colspan="5">
+                     <widget class="QComboBox" name="violinSideCombo"/>
+                    </item>
+                    <item row="18" column="1" colspan="5">
+                     <widget class="QComboBox" name="hist_norm_combo"/>
+                    </item>
+                    <item row="17" column="0">
+                     <widget class="QLabel" name="orientation_label">
+                      <property name="text">
+                       <string>Bar orientation</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="7" column="0">
+                     <widget class="QLabel" name="line_lab">
+                      <property name="text">
+                       <string>Line type</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="10" column="1" colspan="5">
+                     <widget class="QComboBox" name="color_scale_combo"/>
+                    </item>
+                    <item row="5" column="0">
+                     <widget class="QLabel" name="marker_type_lab">
+                      <property name="text">
+                       <string>Marker type</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="17" column="1" colspan="5">
+                     <widget class="QComboBox" name="orientation_combo"/>
+                    </item>
+                    <item row="12" column="1" colspan="5">
+                     <widget class="QComboBox" name="info_combo"/>
+                    </item>
+                    <item row="4" column="3">
+                     <widget class="QLabel" name="marker_width_lab">
+                      <property name="text">
+                       <string>Stroke width</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="19" column="0">
+                     <widget class="QLabel" name="box_statistic_label">
+                      <property name="text">
+                       <string>Show statistics</string>
+                      </property>
+                     </widget>
+                    </item>
                     <item row="8" column="1" colspan="5">
                      <layout class="QHBoxLayout" name="horizontalLayout_4">
                       <item>
@@ -506,9 +621,6 @@ QListWidget::item::selected {
                       </item>
                      </layout>
                     </item>
-                    <item row="6" column="1" colspan="5">
-                     <widget class="QComboBox" name="point_combo"/>
-                    </item>
                     <item row="1" column="0">
                      <widget class="QLabel" name="in_color_lab">
                       <property name="text">
@@ -516,15 +628,15 @@ QListWidget::item::selected {
                       </property>
                      </widget>
                     </item>
-                    <item row="10" column="1" colspan="5">
-                     <widget class="QComboBox" name="color_scale_combo"/>
-                    </item>
-                    <item row="16" column="0">
-                     <widget class="QLabel" name="hist_norm_label">
+                    <item row="4" column="0">
+                     <widget class="QLabel" name="out_color_lab">
                       <property name="text">
-                       <string>Normalization</string>
+                       <string>Stroke color</string>
                       </property>
                      </widget>
+                    </item>
+                    <item row="6" column="1" colspan="5">
+                     <widget class="QComboBox" name="point_combo"/>
                     </item>
                     <item row="4" column="5">
                      <widget class="QgsPropertyOverrideButton" name="stroke_defined_button">
@@ -533,20 +645,14 @@ QListWidget::item::selected {
                       </property>
                      </widget>
                     </item>
-                    <item row="4" column="2">
-                     <widget class="QgsPropertyOverrideButton" name="out_color_defined_button">
+                    <item row="8" column="0">
+                     <widget class="QLabel" name="contour_type_label">
                       <property name="text">
-                       <string>...</string>
+                       <string>Contour type</string>
                       </property>
                      </widget>
                     </item>
-                    <item row="15" column="1" colspan="5">
-                     <widget class="QComboBox" name="orientation_combo"/>
-                    </item>
-                    <item row="16" column="1" colspan="5">
-                     <widget class="QComboBox" name="hist_norm_combo"/>
-                    </item>
-                    <item row="22" column="0" colspan="6">
+                    <item row="24" column="0" colspan="6">
                      <layout class="QHBoxLayout" name="horiz_layout_histogram">
                       <item>
                        <widget class="QCheckBox" name="invert_hist_check">
@@ -570,148 +676,12 @@ QListWidget::item::selected {
                       </item>
                      </layout>
                     </item>
-                    <item row="6" column="0">
-                     <widget class="QLabel" name="point_lab">
+                    <item row="0" column="0">
+                     <widget class="QLabel" name="legend_label">
                       <property name="text">
-                       <string>Point type</string>
+                       <string>Legend title</string>
                       </property>
                      </widget>
-                    </item>
-                    <item row="4" column="1">
-                     <widget class="QgsColorButton" name="out_color_combo">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="7" column="0">
-                     <widget class="QLabel" name="line_lab">
-                      <property name="text">
-                       <string>Line type</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="20" column="0">
-                     <widget class="QCheckBox" name="violinBox">
-                      <property name="toolTip">
-                       <string>If checked, box plots will be overlaid on top of violin plots</string>
-                      </property>
-                      <property name="text">
-                       <string>Include box plots</string>
-                      </property>
-                      <property name="checked">
-                       <bool>true</bool>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="4" column="3">
-                     <widget class="QLabel" name="marker_width_lab">
-                      <property name="text">
-                       <string>Stroke width</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="19" column="0">
-                     <widget class="QLabel" name="violinSideLabel">
-                      <property name="text">
-                       <string>Violin side</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="17" column="0">
-                     <widget class="QLabel" name="box_statistic_label">
-                      <property name="text">
-                       <string>Show statistics</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="11" column="1" colspan="5">
-                     <widget class="QgsOpacityWidget" name="opacity_widget">
-                      <property name="focusPolicy">
-                       <enum>Qt::StrongFocus</enum>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="11" column="0">
-                     <widget class="QLabel" name="alpha_lab">
-                      <property name="text">
-                       <string>Opacity</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="10" column="0">
-                     <widget class="QLabel" name="color_scale_label">
-                      <property name="text">
-                       <string>Color scale</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="1" column="3">
-                     <widget class="QLabel" name="marker_size_lab">
-                      <property name="text">
-                       <string>Marker size</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="23" column="1" colspan="5">
-                     <widget class="QgsSpinBox" name="bins_value">
-                      <property name="enabled">
-                       <bool>false</bool>
-                      </property>
-                      <property name="maximum">
-                       <number>1000</number>
-                      </property>
-                      <property name="value">
-                       <number>10</number>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="2" column="0">
-                     <widget class="QLabel" name="color_scale_data_defined_in_label">
-                      <property name="text">
-                       <string>Color scale</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="1" column="5">
-                     <widget class="QgsPropertyOverrideButton" name="size_defined_button">
-                      <property name="text">
-                       <string>...</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="8" column="0">
-                     <widget class="QLabel" name="contour_type_label">
-                      <property name="text">
-                       <string>Contour type</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="1" column="2">
-                     <widget class="QgsPropertyOverrideButton" name="in_color_defined_button">
-                      <property name="text">
-                       <string>...</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="4" column="4">
-                     <widget class="QgsDoubleSpinBox" name="marker_width"/>
-                    </item>
-                    <item row="12" column="0">
-                     <widget class="QLabel" name="info_label">
-                      <property name="text">
-                       <string>Hover tooltip</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="7" column="1" colspan="5">
-                     <widget class="QComboBox" name="line_combo"/>
-                    </item>
-                    <item row="18" column="1" colspan="5">
-                     <widget class="QComboBox" name="outliers_combo"/>
                     </item>
                     <item row="1" column="1">
                      <widget class="QgsColorButton" name="in_color_combo">
@@ -723,42 +693,12 @@ QListWidget::item::selected {
                       </property>
                      </widget>
                     </item>
-                    <item row="4" column="0">
-                     <widget class="QLabel" name="out_color_lab">
+                    <item row="20" column="0">
+                     <widget class="QLabel" name="outliers_label">
                       <property name="text">
-                       <string>Stroke color</string>
+                       <string>Outliers</string>
                       </property>
                      </widget>
-                    </item>
-                    <item row="14" column="1" colspan="5">
-                     <widget class="QComboBox" name="combo_text_position"/>
-                    </item>
-                    <item row="21" column="0">
-                     <widget class="QCheckBox" name="showMeanCheck">
-                      <property name="text">
-                       <string>Show mean line</string>
-                      </property>
-                      <property name="checked">
-                       <bool>true</bool>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="14" column="0">
-                     <widget class="QLabel" name="label_text_position">
-                      <property name="text">
-                       <string>Label text position</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="13" column="0">
-                     <widget class="QCheckBox" name="hover_as_text_check">
-                      <property name="text">
-                       <string>Hover label as text</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="1" column="4">
-                     <widget class="QgsDoubleSpinBox" name="marker_size"/>
                     </item>
                     <item row="2" column="1" colspan="5">
                      <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="1,0,0">
@@ -784,55 +724,78 @@ QListWidget::item::selected {
                       </item>
                      </layout>
                     </item>
-                    <item row="15" column="0">
-                     <widget class="QLabel" name="orientation_label">
-                      <property name="text">
-                       <string>Bar orientation</string>
-                      </property>
-                     </widget>
+                    <item row="16" column="1" colspan="5">
+                     <widget class="QComboBox" name="combo_text_position"/>
                     </item>
-                    <item row="18" column="0">
-                     <widget class="QLabel" name="outliers_label">
-                      <property name="text">
-                       <string>Outliers</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="17" column="1" colspan="5">
-                     <widget class="QComboBox" name="box_statistic_combo"/>
-                    </item>
-                    <item row="19" column="1" colspan="5">
-                     <widget class="QComboBox" name="violinSideCombo"/>
-                    </item>
-                    <item row="23" column="0">
+                    <item row="25" column="0">
                      <widget class="QCheckBox" name="bins_check">
                       <property name="text">
                        <string>Manual bin size</string>
                       </property>
                      </widget>
                     </item>
-                    <item row="12" column="1" colspan="5">
-                     <widget class="QComboBox" name="info_combo"/>
+                    <item row="12" column="0">
+                     <widget class="QLabel" name="info_label">
+                      <property name="text">
+                       <string>Hover tooltip</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="1" column="3">
+                     <widget class="QLabel" name="marker_size_lab">
+                      <property name="text">
+                       <string>Marker size</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="4" column="1">
+                     <widget class="QgsColorButton" name="out_color_combo">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="6" column="0">
+                     <widget class="QLabel" name="point_lab">
+                      <property name="text">
+                       <string>Point type</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="11" column="0">
+                     <widget class="QLabel" name="alpha_lab">
+                      <property name="text">
+                       <string>Opacity</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="19" column="1" colspan="5">
+                     <widget class="QComboBox" name="box_statistic_combo"/>
+                    </item>
+                    <item row="4" column="4">
+                     <widget class="QgsDoubleSpinBox" name="marker_width"/>
+                    </item>
+                    <item row="22" column="0">
+                     <widget class="QCheckBox" name="violinBox">
+                      <property name="toolTip">
+                       <string>If checked, box plots will be overlaid on top of violin plots</string>
+                      </property>
+                      <property name="text">
+                       <string>Include box plots</string>
+                      </property>
+                      <property name="checked">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
                     </item>
                     <item row="5" column="1" colspan="5">
                      <widget class="QComboBox" name="marker_type_combo"/>
                     </item>
-                    <item row="5" column="0">
-                     <widget class="QLabel" name="marker_type_lab">
-                      <property name="text">
-                       <string>Marker type</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="0" column="0">
-                     <widget class="QLabel" name="legend_label">
-                      <property name="text">
-                       <string>Legend title</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="0" column="1" colspan="4">
-                     <widget class="QLineEdit" name="legend_title"/>
+                    <item row="20" column="1" colspan="5">
+                     <widget class="QComboBox" name="outliers_combo"/>
                     </item>
                     <item row="0" column="5">
                      <widget class="QgsPropertyOverrideButton" name="legend_title_defined_button">
@@ -840,6 +803,53 @@ QListWidget::item::selected {
                        <string>...</string>
                       </property>
                      </widget>
+                    </item>
+                    <item row="18" column="0">
+                     <widget class="QLabel" name="hist_norm_label">
+                      <property name="text">
+                       <string>Normalization</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="7" column="1" colspan="5">
+                     <widget class="QComboBox" name="line_combo"/>
+                    </item>
+                    <item row="23" column="0">
+                     <widget class="QCheckBox" name="showMeanCheck">
+                      <property name="text">
+                       <string>Show mean line</string>
+                      </property>
+                      <property name="checked">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="2" column="0">
+                     <widget class="QLabel" name="color_scale_data_defined_in_label">
+                      <property name="text">
+                       <string>Color scale</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="1" column="4">
+                     <widget class="QgsDoubleSpinBox" name="marker_size"/>
+                    </item>
+                    <item row="1" column="5">
+                     <widget class="QgsPropertyOverrideButton" name="size_defined_button">
+                      <property name="text">
+                       <string>...</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="13" column="0">
+                     <widget class="QLabel" name="additional_info_label">
+                      <property name="text">
+                       <string>Hover label</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="13" column="1" colspan="5">
+                     <widget class="QgsFieldExpressionWidget" name="additional_info_combo"/>
                     </item>
                    </layout>
                   </widget>
@@ -915,89 +925,6 @@ QListWidget::item::selected {
                     <bool>false</bool>
                    </property>
                    <layout class="QGridLayout" name="gridLayout_10">
-                    <item row="7" column="3">
-                     <widget class="QgsPropertyOverrideButton" name="z_axis_title_defined_button">
-                      <property name="text">
-                       <string>...</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="3" column="2">
-                     <widget class="QLineEdit" name="x_axis_title"/>
-                    </item>
-                    <item row="12" column="0">
-                     <widget class="QLabel" name="additional_info_label">
-                      <property name="text">
-                       <string>Additional hover label</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="10" column="0">
-                     <widget class="QLabel" name="bar_mode_lab">
-                      <property name="text">
-                       <string>Bar mode</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="7" column="2">
-                     <widget class="QLineEdit" name="z_axis_title"/>
-                    </item>
-                    <item row="1" column="3">
-                     <widget class="QgsPropertyOverrideButton" name="plot_title_defined_button">
-                      <property name="text">
-                       <string>...</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="7" column="0">
-                     <widget class="QLabel" name="z_axis_label">
-                      <property name="text">
-                       <string>Z label</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="5" column="0">
-                     <widget class="QLabel" name="y_axis_label">
-                      <property name="text">
-                       <string>Y label</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="29" column="2" colspan="2">
-                     <widget class="QgsColorButton" name="layout_grid_axis_color">
-                      <property name="allowOpacity">
-                       <bool>true</bool>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="1" column="0">
-                     <widget class="QLabel" name="plot_title_lab">
-                      <property name="text">
-                       <string>Plot title</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="14" column="2" colspan="2">
-                     <layout class="QHBoxLayout" name="horizontalLayout_10">
-                      <item>
-                       <widget class="QLabel" name="x_axis_mode_label">
-                        <property name="text">
-                         <string>X axis mode</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QComboBox" name="x_axis_mode_combo">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                       </widget>
-                      </item>
-                     </layout>
-                    </item>
                     <item row="5" column="3">
                      <widget class="QgsPropertyOverrideButton" name="y_axis_title_defined_button">
                       <property name="text">
@@ -1005,7 +932,7 @@ QListWidget::item::selected {
                       </property>
                      </widget>
                     </item>
-                    <item row="16" column="2" colspan="2">
+                    <item row="15" column="2" colspan="2">
                      <layout class="QHBoxLayout" name="horizontalLayout_11">
                       <item>
                        <widget class="QLabel" name="y_axis_mode_label">
@@ -1026,20 +953,44 @@ QListWidget::item::selected {
                       </item>
                      </layout>
                     </item>
-                    <item row="12" column="2">
-                     <widget class="QgsFieldExpressionWidget" name="additional_info_combo"/>
-                    </item>
-                    <item row="11" column="0">
-                     <widget class="QLabel" name="bar_gap_label">
-                      <property name="text">
-                       <string>Bar gap</string>
-                      </property>
-                     </widget>
-                    </item>
                     <item row="5" column="2">
                      <widget class="QLineEdit" name="y_axis_title"/>
                     </item>
-                    <item row="27" column="0" colspan="4">
+                    <item row="13" column="0">
+                     <widget class="QCheckBox" name="invert_x_check">
+                      <property name="text">
+                       <string>Invert X axis</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="10" column="0">
+                     <widget class="QLabel" name="bar_mode_lab">
+                      <property name="text">
+                       <string>Bar mode</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="15" column="0">
+                     <widget class="QCheckBox" name="invert_y_check">
+                      <property name="text">
+                       <string>Invert Y axis</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="7" column="2">
+                     <widget class="QLineEdit" name="z_axis_title"/>
+                    </item>
+                    <item row="3" column="3">
+                     <widget class="QgsPropertyOverrideButton" name="x_axis_title_defined_button">
+                      <property name="text">
+                       <string>...</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="10" column="2" colspan="2">
+                     <widget class="QComboBox" name="bar_mode_combo"/>
+                    </item>
+                    <item row="26" column="0" colspan="4">
                      <widget class="QgsCollapsibleGroupBox" name="x_axis_bounds_check">
                       <property name="title">
                        <string>Set X Axis Bounds</string>
@@ -1088,14 +1039,48 @@ QListWidget::item::selected {
                       </layout>
                      </widget>
                     </item>
-                    <item row="29" column="0">
-                     <widget class="QLabel" name="grid_color_label">
+                    <item row="3" column="0">
+                     <widget class="QLabel" name="x_axis_label">
                       <property name="text">
-                       <string>Grid color</string>
+                       <string>X label</string>
                       </property>
                      </widget>
                     </item>
-                    <item row="28" column="0" colspan="4">
+                    <item row="1" column="3">
+                     <widget class="QgsPropertyOverrideButton" name="plot_title_defined_button">
+                      <property name="text">
+                       <string>...</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="11" column="2" colspan="2">
+                     <widget class="QgsDoubleSpinBox" name="bar_gap">
+                      <property name="maximum">
+                       <double>1.000000000000000</double>
+                      </property>
+                      <property name="singleStep">
+                       <double>0.100000000000000</double>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="5" column="0">
+                     <widget class="QLabel" name="y_axis_label">
+                      <property name="text">
+                       <string>Y label</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="1" column="2">
+                     <widget class="QLineEdit" name="plot_title_line"/>
+                    </item>
+                    <item row="7" column="3">
+                     <widget class="QgsPropertyOverrideButton" name="z_axis_title_defined_button">
+                      <property name="text">
+                       <string>...</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="27" column="0" colspan="4">
                      <widget class="QgsCollapsibleGroupBox" name="y_axis_bounds_check">
                       <property name="title">
                        <string>Set Y Axis Bounds</string>
@@ -1144,47 +1129,24 @@ QListWidget::item::selected {
                       </layout>
                      </widget>
                     </item>
-                    <item row="1" column="2">
-                     <widget class="QLineEdit" name="plot_title_line"/>
-                    </item>
-                    <item row="10" column="2" colspan="2">
-                     <widget class="QComboBox" name="bar_mode_combo"/>
-                    </item>
-                    <item row="3" column="0">
-                     <widget class="QLabel" name="x_axis_label">
+                    <item row="11" column="0">
+                     <widget class="QLabel" name="bar_gap_label">
                       <property name="text">
-                       <string>X label</string>
+                       <string>Bar gap</string>
                       </property>
                      </widget>
                     </item>
-                    <item row="14" column="0">
-                     <widget class="QCheckBox" name="invert_x_check">
+                    <item row="28" column="0">
+                     <widget class="QLabel" name="grid_color_label">
                       <property name="text">
-                       <string>Invert X axis</string>
+                       <string>Grid color</string>
                       </property>
                      </widget>
                     </item>
-                    <item row="3" column="3">
-                     <widget class="QgsPropertyOverrideButton" name="x_axis_title_defined_button">
+                    <item row="7" column="0">
+                     <widget class="QLabel" name="z_axis_label">
                       <property name="text">
-                       <string>...</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="16" column="0">
-                     <widget class="QCheckBox" name="invert_y_check">
-                      <property name="text">
-                       <string>Invert Y axis</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="11" column="2" colspan="2">
-                     <widget class="QgsDoubleSpinBox" name="bar_gap">
-                      <property name="maximum">
-                       <double>1.000000000000000</double>
-                      </property>
-                      <property name="singleStep">
-                       <double>0.100000000000000</double>
+                       <string>Z label</string>
                       </property>
                      </widget>
                     </item>
@@ -1211,6 +1173,44 @@ QListWidget::item::selected {
                        <widget class="QCheckBox" name="range_slider_combo">
                         <property name="text">
                          <string>Show range slider</string>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
+                    </item>
+                    <item row="28" column="2" colspan="2">
+                     <widget class="QgsColorButton" name="layout_grid_axis_color">
+                      <property name="allowOpacity">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="1" column="0">
+                     <widget class="QLabel" name="plot_title_lab">
+                      <property name="text">
+                       <string>Plot title</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="3" column="2">
+                     <widget class="QLineEdit" name="x_axis_title"/>
+                    </item>
+                    <item row="13" column="2" colspan="2">
+                     <layout class="QHBoxLayout" name="horizontalLayout_10">
+                      <item>
+                       <widget class="QLabel" name="x_axis_mode_label">
+                        <property name="text">
+                         <string>X axis mode</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QComboBox" name="x_axis_mode_combo">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
                         </property>
                        </widget>
                       </item>


### PR DESCRIPTION
* when opening the panel the focus should be to the main page (is was on the plot customization one)
* move the additional hover label to the main plot properties page
* enable the opacity widget for the pie plot
* remove useless widget for 2dhistogram

@SGroe the layout is the following:

![image](https://user-images.githubusercontent.com/2884884/112950289-67c49800-913a-11eb-8fba-4c157aa59793.png)

I see tests are failing because of pylint not because of some core changes. Is there any reason tests are failing with pylint... suggestions welcome on how to fix it :) 