### PR TITLE
Fix TypeError with Python 3.10

### DIFF
--- a/DataPlotly/layouts/plot_layout_item.py
+++ b/DataPlotly/layouts/plot_layout_item.py
@@ -218,8 +218,8 @@ class PlotLayoutItem(QgsLayoutItem):
     def load_content(self):
         self.html_loaded = False
         base_url = QUrl.fromLocalFile(self.layout().project().absoluteFilePath())
-        self.web_page.setViewportSize(QSize(self.rect().width() * self.html_units_to_layout_units,
-                                            self.rect().height() * self.html_units_to_layout_units))
+        self.web_page.setViewportSize(QSize(int(self.rect().width()) * self.html_units_to_layout_units,
+                                            int(self.rect().height()) * self.html_units_to_layout_units))
         self.web_page.mainFrame().setHtml(self.create_plot(), base_url)
 
     def writePropertiesToElement(self, element, document, _) -> bool:


### PR DESCRIPTION
Float now requires explicit cast to int