### PR TITLE
update QGIS release in testing suite

### DIFF
--- a/.github/workflows/test_plugin.yaml
+++ b/.github/workflows/test_plugin.yaml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        docker_tags: [release-3_16, release-3_18, latest]
+        docker_tags: [release-3_16, release-3_22, latest]
 
     steps:
 


### PR DESCRIPTION
@nyalldawson I know that it could a little bit overkilling, but is there an automatic way to ping use when a QGIS release is obsolete so we can update the docker image to pull?