### PR TITLE
Fix correct version in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 3.10 - 2022-08-23
+## 3.9.2 - 2022-08-30
 
 - test added for Processing
 - Processing algorithm refactored using plotly.express (scatter plot)


### PR DESCRIPTION
The tag this morning was 3.9.2

The bot didn't find the release content so it took the commit content
https://github.com/ghtmtt/DataPlotly/releases/tag/3.9.2