### PR TITLE
Auto create clear plot

### DIFF
--- a/DataPlotly/gui/plot_settings_widget.py
+++ b/DataPlotly/gui/plot_settings_widget.py
@@ -364,8 +364,6 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
         # new dock instance from project
         if project:
             self.read_project(project)
-            # FIXME: creation plot is not working
-            # self.create_plot()
 
     def updateStacked(self, row):
         """
@@ -1668,6 +1666,7 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
         if settings.read_from_project(document):
             # update the dock state to match the read settings
             self.set_settings(settings)
+            self.create_plot()          
 
     def load_configuration(self):
         """

--- a/DataPlotly/gui/plot_settings_widget.py
+++ b/DataPlotly/gui/plot_settings_widget.py
@@ -116,6 +116,7 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
         # listen out for project save/restore, and update our state accordingly
         QgsProject.instance().writeProject.connect(self.write_project)
         QgsProject.instance().readProject.connect(self.read_project)
+        QgsProject.instance().cleared.connect(self.clearPlotView)
 
         if self.iface is not None:
             self.listWidget.setIconSize(self.iface.iconSize(False))

--- a/DataPlotly/gui/plot_settings_widget.py
+++ b/DataPlotly/gui/plot_settings_widget.py
@@ -1667,7 +1667,7 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
         if settings.read_from_project(document):
             # update the dock state to match the read settings
             self.set_settings(settings)
-            self.create_plot()          
+            self.create_plot()
 
     def load_configuration(self):
         """


### PR DESCRIPTION
Minimal improvment : finally I find a way to create plot when project is readed :)

## Before

We have to click on the button to create the plot. When project is cleared, the plot view is not cleared

![dataplot_auto_create_clear_before](https://user-images.githubusercontent.com/8641271/231756931-3ad118a4-c2f1-487f-8661-6ad703c0d128.gif)


## After

No needs anymoreto click on the button to create the plot. When project is cleared, the plot view is  now cleared

![dataplot_auto_create_clear_after](https://user-images.githubusercontent.com/8641271/231756968-1e1a0edd-e607-4e59-88e2-fedd1c4636bb.gif)

