### PR TITLE
Fix bar width

### DIFF
--- a/.github/workflows/test_plugin.yaml
+++ b/.github/workflows/test_plugin.yaml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        docker_tags: [release-3_22, release-3_28, latest]
+        docker_tags: [release-3_28, latest]
 
     steps:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 4.0.1 2023-05-12
+
+- tweak the bar width values, usefull with time series
+- minimum QGIS version to 3.28 LTR
+
 ## 4.0.0 - 2023-04-17
 
 - multiple plot docks thanks to @jdlom

--- a/DataPlotly/core/plot_types/bar_plot.py
+++ b/DataPlotly/core/plot_types/bar_plot.py
@@ -42,6 +42,15 @@ class BarPlotFactory(PlotType):
             x = settings.x
             y = settings.y
 
+        # tweak the width value
+        if settings.data_defined_marker_sizes:
+            width = settings.data_defined_marker_sizes
+        # set to None if 0.0 or Auto, useful especially for date/datetime data
+        elif settings.properties['marker_size'] == 0.0:
+            width = None
+        else:
+            width = settings.properties['marker_size']
+
         return [graph_objs.Bar(
             x=x,
             y=y,
@@ -62,7 +71,7 @@ class BarPlotFactory(PlotType):
                         'color': settings.data_defined_stroke_colors if settings.data_defined_stroke_colors else settings.properties['out_color'],
                         'width': settings.data_defined_stroke_widths if settings.data_defined_stroke_widths else settings.properties['marker_width']}
                     },
-            width=settings.data_defined_marker_sizes if settings.data_defined_marker_sizes else settings.properties['marker_size'],
+            width=width,
             opacity=settings.properties['opacity']
         )]
 

--- a/DataPlotly/gui/plot_settings_widget.py
+++ b/DataPlotly/gui/plot_settings_widget.py
@@ -836,7 +836,9 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
         # change the label and the spin box value when the bar plot is chosen
         if self.ptype == 'bar':
             self.marker_size_lab.setText(self.tr('Bar width'))
-            self.marker_size.setValue(0.5)
+            self.marker_size.setValue(0.0)
+            self.marker_size.setClearValue(0.0, self.tr('Auto'))
+            self.marker_size.setToolTip(self.tr('Set to Auto to automatically resize the bar width'))
 
         # change the label and the spin box value when the scatter plot is chosen
         if self.ptype == 'scatter':

--- a/DataPlotly/metadata.txt
+++ b/DataPlotly/metadata.txt
@@ -1,6 +1,6 @@
 [general]
 name=Data Plotly
-qgisMinimumVersion=3.4
+qgisMinimumVersion=3.28
 qgisMaximumVersion=3.98
 description=D3 Plots for QGIS
 author=Matteo Ghetta (Faunalia)


### PR DESCRIPTION
New option to set the bar width to automatically. Especially useful with time series where the bar width should be manually calculated to milliseconds. With the `Auto` option enabled, the plotly backend will take care of it