### PR TITLE
Fix loading of the plugin without panda installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix loading of the plugin when the Pandas library is not found, contribution from @Gustry
+
 ## 4.0.3 - 2023-06-27
 
 - fix bug with old projects (second part) thanks to @jdlom

--- a/DataPlotly/processing/dataplotly_provider.py
+++ b/DataPlotly/processing/dataplotly_provider.py
@@ -19,9 +19,18 @@
  *                                                                         *
  ***************************************************************************/
 """
-from qgis.core import QgsProcessingProvider
+from qgis.core import Qgis, QgsMessageLog, QgsProcessingProvider
 from DataPlotly.gui.gui_utils import GuiUtils
-from DataPlotly.processing.dataplotly_scatterplot import DataPlotlyProcessingScatterPlot
+
+try:
+    # 🐼
+    from DataPlotly.processing.dataplotly_scatterplot import DataPlotlyProcessingScatterPlot
+    WITH_PANDAS = True
+except ImportError:
+    WITH_PANDAS = False
+    QgsMessageLog.logMessage(
+        "Pandas has not been found. The processing algorithm will not be loaded. "
+        "Please install qgis-full or qgis standalone", "DataPlotly", Qgis.Warning)
 
 
 class DataPlotlyProvider(QgsProcessingProvider):
@@ -76,4 +85,5 @@ class DataPlotlyProvider(QgsProcessingProvider):
         even if the list does not change, since the self.algs list is
         cleared before calling this method.
         """
-        self.addAlgorithm(DataPlotlyProcessingScatterPlot())
+        if WITH_PANDAS:
+            self.addAlgorithm(DataPlotlyProcessingScatterPlot())


### PR DESCRIPTION
Fix to #331

Maybe a more visible warning will be better to invite users to install it. But at least, the plugin can load without a Python error