### PR TITLE
Do not add docks if self.iface is not defined when using qgis_process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix loading of the plugin when used with `qgis_process`, contribution from @Gustry
+
 ## 4.1.0 - 2023-11-15
 
 - Fix loading of the plugin when the Pandas library is not found, contribution from @Gustry

--- a/DataPlotly/gui/dock.py
+++ b/DataPlotly/gui/dock.py
@@ -127,7 +127,7 @@ class DataPlotlyDockManager():
                 # FIXME : trigger the plot creation (not working)
                 # main_panel = self.getDock(tag_name).main_panel
                 # main_panel.create_plot()
-        if self.read_from_project(document):
+        if self.iface and self.read_from_project(document):
             self.iface.mainWindow().restoreGeometry(self.geometry)
             self.iface.mainWindow().restoreState(self.state, version=999)
         return True


### PR DESCRIPTION
To avoid the Python error with `qgis_process` : 

```bash
➜ qgis_process run native:atlaslayouttomultiplepdf --distance_units=meters --area_units=m2 --ellipsoid=NONE --project_path=/home/etienne/dev/python/lizmap-plugin/lizmap/test/data/lizmap_3_3.qgs --LAYOUT=landscape --COVERAGE_LAYER=/home/etienne/dev/python/lizmap-plugin/lizmap/test/data/lines.geojson --FILTER_EXPRESSION= --SORTBY_EXPRESSION= --SORTBY_REVERSE=false --FORCE_VECTOR=false --FORCE_RASTER=false --GEOREFERENCE=true --INCLUDE_METADATA=true --DISABLE_TILED=false --SIMPLIFY=true --TEXT_FORMAT=0 --IMAGE_COMPRESSION=0 --OUTPUT_FILENAME= --OUTPUT_FOLDER=/tmp/
Traceback (most recent call last):
  File "/home/etienne/.local/share/QGIS/QGIS3/profiles/default/python/plugins/DataPlotly/gui/dock.py", line 131, in addDocksFromProject
    self.iface.mainWindow().restoreGeometry(self.geometry)
AttributeError: 'NoneType' object has no attribute 'mainWindow'

```

For sure, a lot of code execution can be avoided with qgis_process with these Dock.