### PR TITLE
Feature pie labels and scale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ DataPlotly/i18n/
 
 # Test
 *.qgs~
+/.vs

--- a/DataPlotly/core/plot_factory.py
+++ b/DataPlotly/core/plot_factory.py
@@ -413,6 +413,20 @@ class PlotFactory(QObject):  # pylint:disable=too-many-instance-attributes
             value, _ = self.settings.data_defined_properties.valueAsDouble(PlotSettings.PROPERTY_Y_MAX,
                                                                            context, default_value)
             y_max = value
+        pie_label = None 
+        if self.settings.data_defined_properties.isActive(PlotSettings.PROPERTY_PIE_LABEL):
+            default_value = self.settings.layout['pie_label']
+            context.setOriginalValueVariable(default_value)
+            value, _ = self.settings.data_defined_properties.valueAsString(PlotSettings.PROPERTY_PIE_LABEL,
+                                                                           context, default_value)
+            pie_label = value
+        zoom_factor = None
+        if self.settings.data_defined_properties.isActive(PlotSettings.PROPERTY_ZOOM_FACTOR):
+            default_value = self.settings.layout['zoom_factor']
+            context.setOriginalValueVariable(default_value)
+            value, _ = self.settings.data_defined_properties.valueAsDouble(PlotSettings.PROPERTY_ZOOM_FACTOR,
+                                                                           context, default_value)
+            zoom_factor = value
 
         self.settings.data_defined_title = title
         self.settings.data_defined_legend_title = legend_title
@@ -423,6 +437,7 @@ class PlotFactory(QObject):  # pylint:disable=too-many-instance-attributes
         self.settings.data_defined_x_max = x_max
         self.settings.data_defined_y_min = y_min
         self.settings.data_defined_y_max = y_max
+        self.settings.data_defined_zoom_factor = zoom_factor
 
     def set_visible_region(self, region: QgsReferencedRectangle):
         """

--- a/DataPlotly/core/plot_settings.py
+++ b/DataPlotly/core/plot_settings.py
@@ -46,6 +46,8 @@ class PlotSettings:  # pylint: disable=too-many-instance-attributes
     PROPERTY_FONT_YTICKS_SIZE = 27
     PROPERTY_FONT_YTICKS_FAMILY = 28
     PROPERTY_FONT_YTICKS_COLOR = 29
+    PROPERTY_PIE_LABEL = 30
+    PROPERTY_ZOOM_FACTOR = 31
 
     DYNAMIC_PROPERTIES = {
         PROPERTY_FILTER: QgsPropertyDefinition('filter', 'Feature filter', QgsPropertyDefinition.Boolean),
@@ -78,7 +80,9 @@ class PlotSettings:  # pylint: disable=too-many-instance-attributes
         PROPERTY_X_MIN: QgsPropertyDefinition('x_min', 'X axis minimum', QgsPropertyDefinition.Double),
         PROPERTY_X_MAX: QgsPropertyDefinition('x_max', 'X axis maximum', QgsPropertyDefinition.Double),
         PROPERTY_Y_MIN: QgsPropertyDefinition('y_min', 'Y axis minimum', QgsPropertyDefinition.Double),
-        PROPERTY_Y_MAX: QgsPropertyDefinition('y_max', 'Y axis maximum', QgsPropertyDefinition.Double)
+        PROPERTY_Y_MAX: QgsPropertyDefinition('y_max', 'Y axis maximum', QgsPropertyDefinition.Double),
+        PROPERTY_PIE_LABEL: QgsPropertyDefinition('pie_label', 'Pie chart labels as:', QgsPropertyDefinition.String),
+        PROPERTY_ZOOM_FACTOR: QgsPropertyDefinition('zoom_factor', 'Chart zoom factor', QgsPropertyDefinition.Double)
     }
 
     # pylint: disable=too-many-arguments
@@ -130,7 +134,8 @@ class PlotSettings:  # pylint: disable=too-many-instance-attributes
             'show_mean_line': False,
             'layout_filter_by_map': False,
             'layout_filter_by_atlas': False,
-            'pie_hole': 0
+            'pie_hole': 0,
+            'pie_labels':'Values'
         }
 
         # layout nested dictionary
@@ -172,7 +177,8 @@ class PlotSettings:  # pylint: disable=too-many-instance-attributes
             'polar': {'angularaxis': {'direction': 'clockwise'}},
             'additional_info_expression': '',
             'bins_check': False,
-            'gridcolor': '#bdbfc0'
+            'gridcolor': '#bdbfc0',
+            'zoom_factor': 10.0
         }
 
         self.plot_base_dic = {
@@ -217,7 +223,9 @@ class PlotSettings:  # pylint: disable=too-many-instance-attributes
         self.data_defined_x_max = None
         self.data_defined_y_min = None
         self.data_defined_y_max = None
+        self.data_defined_zoom_factor = None
         self.source_layer_id = source_layer_id
+        
 
         # multiple_dock
         self.dock_title = dock_title

--- a/DataPlotly/gui/plot_settings_widget.py
+++ b/DataPlotly/gui/plot_settings_widget.py
@@ -170,6 +170,10 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
         self.marker_width.setValue(1)
         self.marker_width.setSingleStep(0.2)
         self.marker_width.setClearValue(0, self.tr('None'))
+        
+        self.zoom_factor.setValue(10)
+        self.zoom_factor.setSingleStep(0.2)
+        self.zoom_factor.setClearValue(10)
 
         # pie_hole
         self.pie_hole.setClearValue(0, self.tr('None'))
@@ -188,6 +192,10 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
         # SubPlots combobox
         self.subcombo.addItem(self.tr('Single Plot'), 'single')
         self.subcombo.addItem(self.tr('Subplots'), 'subplots')
+        
+        # Pie labels combobox
+        self.pieLabelsCombo.addItem(self.tr('Percentages'), 0)
+        self.pieLabelsCombo.addItem(self.tr('Values'), 1)
 
         # connect to the functions to clean the UI and fill with the correct
         # widgets
@@ -868,6 +876,7 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
             # plot properties
             self.layer_combo: ['all'],
             self.feature_subset_defined_button: ['all'],
+            self.zoom_factor: ['all'],
             self.x_label: ['all'],
             self.x_combo: ['all'],
             self.y_label: ['scatter', 'bar', 'box', 'pie', '2dhistogram', 'polar', 'ternary', 'contour', 'violin'],
@@ -989,6 +998,8 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
             self.violinBox: ['violin'],
             self.pie_hole_label : ['pie'],
             self.pie_hole : ['pie'],
+            self.pieLabelsLabel : ['pie'],
+            self.pieLabelsCombo : ['pie'], 
         }
 
         # enable the widget according to the plot type
@@ -1026,6 +1037,12 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
             self.radio_rows.setVisible(False)
             self.radio_columns.setEnabled(False)
             self.radio_columns.setVisible(False)
+            
+    def updatePieLabels(self):
+        """
+        Update the store value when this is changed
+        """
+        pass
 
     def refreshWidgets3(self):
         """
@@ -1099,6 +1116,7 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
                            'out_color': self.out_color_combo.color().name(),
                            'marker_width': self.marker_width.value(),
                            'marker_size': self.marker_size.value(),
+                           'zoom_factor': self.zoom_factor.value(),
                            'marker_symbol': self.point_types2[self.point_combo.currentData()],
                            'line_dash': self.line_types2[self.line_combo.currentText()],
                            'box_orientation': self.orientation_combo.currentData(),
@@ -1128,7 +1146,8 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
                            'show_lines_check': self.show_lines_check.isChecked(),
                            'layout_filter_by_map': self.filter_by_map_check.isChecked(),
                            'layout_filter_by_atlas': self.filter_by_atlas_check.isChecked(),
-                           'pie_hole' : self.pie_hole.value()
+                           'pie_hole' : self.pie_hole.value(),
+                           'pie_labels' : self.pieLabelsCombo.currentText(),
                            }
 
         if self.in_color_defined_button.isActive():
@@ -1251,6 +1270,7 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
         self.out_color_combo.setColor(
             QColor(settings.properties.get('out_color', '#1f77b4')))
         self.marker_width.setValue(settings.properties.get('marker_width', 1))
+        self.zoom_factor.setValue(settings.properties.get('zoom_factor', 10))
         self.marker_type_combo.setCurrentText(
             settings.properties.get('marker_type_combo', 'Points'))
         self.point_combo.setCurrentText(
@@ -1357,6 +1377,8 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
         self.layout_grid_axis_color.setColor(
             QColor(settings.layout.get('gridcolor') or '#bdbfc0'))
         self.pie_hole.setValue(settings.properties.get('pie_hole', 0))
+        self.pieLabelsCombo.setCurrentText(
+            settings.properties.get('pie_labels', 'Values'))
 
     def create_plot_factory(self) -> PlotFactory:
         """

--- a/DataPlotly/ui/dataplotly_dockwidget_base.ui
+++ b/DataPlotly/ui/dataplotly_dockwidget_base.ui
@@ -320,9 +320,9 @@ QListWidget::item::selected {
                 <property name="geometry">
                  <rect>
                   <x>0</x>
-                  <y>-270</y>
-                  <width>673</width>
-                  <height>989</height>
+                  <y>0</y>
+                  <width>669</width>
+                  <height>1052</height>
                  </rect>
                 </property>
                 <layout class="QGridLayout" name="gridLayout_9">
@@ -357,6 +357,77 @@ QListWidget::item::selected {
                     <string>Plot Parameters</string>
                    </property>
                    <layout class="QGridLayout" name="gridLayout_23">
+                    <item row="6" column="1" colspan="2">
+                     <widget class="QCheckBox" name="filter_by_atlas_check">
+                      <property name="text">
+                       <string>Use only features inside atlas feature</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="5" column="1" colspan="2">
+                     <widget class="QCheckBox" name="filter_by_map_check">
+                      <property name="text">
+                       <string>Use only features visible in map</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="2" column="2">
+                     <widget class="QCheckBox" name="visible_feature_check">
+                      <property name="enabled">
+                       <bool>true</bool>
+                      </property>
+                      <property name="text">
+                       <string>Use only visible features</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="3" column="1">
+                     <widget class="QgsPropertyOverrideButton" name="feature_subset_defined_button">
+                      <property name="text">
+                       <string>...</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="7" column="1" colspan="2">
+                     <widget class="QgsFieldExpressionWidget" name="x_combo"/>
+                    </item>
+                    <item row="4" column="0">
+                     <widget class="QLabel" name="label_linked_map">
+                      <property name="text">
+                       <string>Linked map</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="4" column="1" colspan="2">
+                     <widget class="QgsLayoutItemComboBox" name="linked_map_combo"/>
+                    </item>
+                    <item row="3" column="0">
+                     <widget class="QLabel" name="label_feature_subset">
+                      <property name="text">
+                       <string>Feature subset</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="0" column="1" colspan="2">
+                     <widget class="QgsMapLayerComboBox" name="layer_combo">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="2" column="1">
+                     <widget class="QCheckBox" name="selected_feature_check">
+                      <property name="enabled">
+                       <bool>true</bool>
+                      </property>
+                      <property name="text">
+                       <string>Use only selected features</string>
+                      </property>
+                     </widget>
+                    </item>
                     <item row="8" column="0">
                      <widget class="QLabel" name="y_label">
                       <property name="text">
@@ -364,8 +435,15 @@ QListWidget::item::selected {
                       </property>
                      </widget>
                     </item>
-                    <item row="4" column="1" colspan="2">
-                     <widget class="QgsLayoutItemComboBox" name="linked_map_combo"/>
+                    <item row="9" column="1" colspan="2">
+                     <widget class="QgsFieldExpressionWidget" name="z_combo"/>
+                    </item>
+                    <item row="0" column="0">
+                     <widget class="QLabel" name="layer_label">
+                      <property name="text">
+                       <string>Layer</string>
+                      </property>
+                     </widget>
                     </item>
                     <item row="7" column="0">
                      <widget class="QLabel" name="x_label">
@@ -392,12 +470,8 @@ QListWidget::item::selected {
                       </property>
                      </widget>
                     </item>
-                    <item row="6" column="1" colspan="2">
-                     <widget class="QCheckBox" name="filter_by_atlas_check">
-                      <property name="text">
-                       <string>Use only features inside atlas feature</string>
-                      </property>
-                     </widget>
+                    <item row="8" column="1" colspan="2">
+                     <widget class="QgsFieldExpressionWidget" name="y_combo"/>
                     </item>
                     <item row="9" column="0">
                      <widget class="QLabel" name="z_label">
@@ -406,77 +480,17 @@ QListWidget::item::selected {
                       </property>
                      </widget>
                     </item>
-                    <item row="5" column="1" colspan="2">
-                     <widget class="QCheckBox" name="filter_by_map_check">
+                    <item row="10" column="0">
+                     <widget class="QLabel" name="zoom_factor_lab">
                       <property name="text">
-                       <string>Use only features visible in map</string>
+                       <string>Zoom Factor</string>
                       </property>
                      </widget>
                     </item>
-                    <item row="3" column="1">
-                     <widget class="QgsPropertyOverrideButton" name="feature_subset_defined_button">
-                      <property name="text">
-                       <string>...</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="8" column="1" colspan="2">
-                     <widget class="QgsFieldExpressionWidget" name="y_combo"/>
-                    </item>
-                    <item row="0" column="1" colspan="2">
-                     <widget class="QgsMapLayerComboBox" name="layer_combo">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="4" column="0">
-                     <widget class="QLabel" name="label_linked_map">
-                      <property name="text">
-                       <string>Linked map</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="2" column="1">
-                     <widget class="QCheckBox" name="selected_feature_check">
-                      <property name="enabled">
-                       <bool>true</bool>
-                      </property>
-                      <property name="text">
-                       <string>Use only selected features</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="9" column="1" colspan="2">
-                     <widget class="QgsFieldExpressionWidget" name="z_combo"/>
-                    </item>
-                    <item row="7" column="1" colspan="2">
-                     <widget class="QgsFieldExpressionWidget" name="x_combo"/>
-                    </item>
-                    <item row="2" column="2">
-                     <widget class="QCheckBox" name="visible_feature_check">
-                      <property name="enabled">
-                       <bool>true</bool>
-                      </property>
-                      <property name="text">
-                       <string>Use only visible features</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="0" column="0">
-                     <widget class="QLabel" name="layer_label">
-                      <property name="text">
-                       <string>Layer</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="3" column="0">
-                     <widget class="QLabel" name="label_feature_subset">
-                      <property name="text">
-                       <string>Feature subset</string>
+                    <item row="10" column="1">
+                     <widget class="QgsDoubleSpinBox" name="zoom_factor">
+                      <property name="value">
+                       <double>0.000000000000000</double>
                       </property>
                      </widget>
                     </item>
@@ -491,10 +505,10 @@ QListWidget::item::selected {
                    <layout class="QGridLayout" name="gridLayout_22">
                     <item row="14" column="1" colspan="5">
                      <widget class="QComboBox" name="combo_text_position"/>
-                      </item>
+                    </item>
                     <item row="1" column="5">
                      <widget class="QgsPropertyOverrideButton" name="size_defined_button">
-                        <property name="text">
+                      <property name="text">
                        <string>...</string>
                       </property>
                      </widget>
@@ -516,12 +530,12 @@ QListWidget::item::selected {
                       </property>
                       <property name="text">
                        <string>Include box plots</string>
-                        </property>
-                        <property name="checked">
-                         <bool>true</bool>
-                        </property>
-                       </widget>
-                      </item>
+                      </property>
+                      <property name="checked">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
                     <item row="19" column="0">
                      <widget class="QLabel" name="violinSideLabel">
                       <property name="text">
@@ -555,25 +569,25 @@ QListWidget::item::selected {
                     </item>
                     <item row="1" column="0">
                      <widget class="QLabel" name="in_color_lab">
-                        <property name="text">
+                      <property name="text">
                        <string>Marker color</string>
-                        </property>
-                       </widget>
-                      </item>
+                      </property>
+                     </widget>
+                    </item>
                     <item row="2" column="0">
                      <widget class="QLabel" name="color_scale_data_defined_in_label">
                       <property name="text">
                        <string>Color scale</string>
-                        </property>
+                      </property>
                      </widget>
                     </item>
                     <item row="1" column="2">
                      <widget class="QgsPropertyOverrideButton" name="in_color_defined_button">
-                        <property name="text">
+                      <property name="text">
                        <string>...</string>
-                        </property>
-                       </widget>
-                      </item>
+                      </property>
+                     </widget>
+                    </item>
                     <item row="5" column="1" colspan="5">
                      <widget class="QComboBox" name="marker_type_combo"/>
                     </item>
@@ -601,21 +615,21 @@ QListWidget::item::selected {
                       </item>
                       <item>
                        <widget class="QCheckBox" name="color_scale_data_defined_in_check">
-                      <property name="text">
+                        <property name="text">
                          <string>Visible</string>
-                      </property>
-                      <property name="checked">
-                       <bool>true</bool>
-                      </property>
-                     </widget>
-                    </item>
+                        </property>
+                        <property name="checked">
+                         <bool>true</bool>
+                        </property>
+                       </widget>
+                      </item>
                       <item>
                        <widget class="QCheckBox" name="color_scale_data_defined_in_invert_check">
-                      <property name="text">
+                        <property name="text">
                          <string>Invert color</string>
-                      </property>
-                     </widget>
-                    </item>
+                        </property>
+                       </widget>
+                      </item>
                      </layout>
                     </item>
                     <item row="18" column="0">
@@ -682,12 +696,12 @@ QListWidget::item::selected {
                        <widget class="QCheckBox" name="show_lines_check">
                         <property name="text">
                          <string>Show lines</string>
-                      </property>
+                        </property>
                         <property name="checked">
                          <bool>true</bool>
-                      </property>
-                     </widget>
-                    </item>
+                        </property>
+                       </widget>
+                      </item>
                      </layout>
                     </item>
                     <item row="23" column="0" colspan="6">
@@ -697,21 +711,21 @@ QListWidget::item::selected {
                         <property name="enabled">
                          <bool>true</bool>
                         </property>
-                      <property name="text">
+                        <property name="text">
                          <string>Invert histogram direction</string>
-                      </property>
-                     </widget>
-                    </item>
+                        </property>
+                       </widget>
+                      </item>
                       <item>
                        <widget class="QCheckBox" name="cumulative_hist_check">
                         <property name="enabled">
                          <bool>true</bool>
                         </property>
-                      <property name="text">
+                        <property name="text">
                          <string>Cumulative histogram</string>
-                      </property>
-                     </widget>
-                    </item>
+                        </property>
+                       </widget>
+                      </item>
                      </layout>
                     </item>
                     <item row="4" column="5">
@@ -795,18 +809,18 @@ QListWidget::item::selected {
                     </item>
                     <item row="4" column="3">
                      <widget class="QLabel" name="marker_width_lab">
-                        <property name="text">
+                      <property name="text">
                        <string>Stroke width</string>
-                        </property>
-                       </widget>
-                      </item>
+                      </property>
+                     </widget>
+                    </item>
                     <item row="17" column="0">
                      <widget class="QLabel" name="box_statistic_label">
-                        <property name="text">
+                      <property name="text">
                        <string>Show statistics</string>
-                        </property>
-                       </widget>
-                      </item>
+                      </property>
+                     </widget>
+                    </item>
                     <item row="18" column="1" colspan="5">
                      <widget class="QComboBox" name="outliers_combo"/>
                     </item>
@@ -864,6 +878,16 @@ QListWidget::item::selected {
                       </property>
                      </widget>
                     </item>
+                    <item row="20" column="2">
+                     <widget class="QLabel" name="pieLabelsLabel">
+                      <property name="text">
+                       <string>Pie Labels</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="20" column="3" colspan="3">
+                     <widget class="QComboBox" name="pieLabelsCombo"/>
+                    </item>
                    </layout>
                   </widget>
                  </item>
@@ -906,8 +930,8 @@ QListWidget::item::selected {
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>414</width>
-                  <height>583</height>
+                  <width>407</width>
+                  <height>845</height>
                  </rect>
                 </property>
                 <layout class="QGridLayout" name="gridLayout_25" columnstretch="0,0,0">


### PR DESCRIPTION
The current version of the plugin allows you to add a pie chart but the labels are in percentages and there appeared to be no way to configure this. 

I have a use case where I would like the pie to be labelled with the actual values rather than the relative percentage and I found information online stating that you can use the "text": [] object to achieve this goal. 

I was unable to work out how to do this without doing a regex replacement after the HTML is created but I was able to successfully test the changes in my local QGIS and convert the percentages of a pie chart from percentage to value. 

I also found that if a pie chart item is small then the chart becomes unusable so I also added the ability to override the default scale of 10.0 with a lower number. The results of my initial test are shown in the following screenshots:
Before:
![image](https://github.com/ghtmtt/DataPlotly/assets/109313819/6c144646-753f-4e20-b4a5-a5ccd2d225e7)

After:
![image](https://github.com/ghtmtt/DataPlotly/assets/109313819/c85f74ed-a5e4-4c5c-b8bf-70d988469186)
© Crown copyright [and database rights] [2024] AC0000830671.