### PR TITLE
Update metadata.txt about homePage

### DIFF
--- a/DataPlotly/metadata.txt
+++ b/DataPlotly/metadata.txt
@@ -8,6 +8,7 @@ email=matteo.ghetta@gmail.com
 
 about=Draw D3 plots in QGIS
 
+homepage=https://github.com/ghtmtt/DataPlotly/blob/master/README.md
 tracker=https://github.com/ghtmtt/DataPlotly/issues
 repository=https://github.com/ghtmtt/DataPlotly
 # End of mandatory metadata
@@ -25,7 +26,6 @@ dateTime=
 # Tags are comma separated with spaces allowed
 tags=python, d3, plots, vector, graphs, datavis, dataviz, dataplotly
 
-homepage=https://github.com/ghtmtt/DataPlotly
 category=Plugins
 icon=icon.png
 # experimental flag


### PR DESCRIPTION
I'm starting updating some plugins about their URL (related to Lizmap BTW, in the latest release of server side)

* repository : The GIT repository
* tracker : the issue tracker
* homepage : the more UI friendly page for presenting the plugin, so I'm suggesting to redirect straight to the README.md ?

I'm agree, still not the best, but a little bit better ?

Do you have another link in mind or soon ? Github Pages with help ?