### PR TITLE
Deepcopy settings when creating factories

### DIFF
--- a/DataPlotly/core/plot_factory.py
+++ b/DataPlotly/core/plot_factory.py
@@ -7,11 +7,13 @@ the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
 """
 
+
 import tempfile
 import os
 import re
 import plotly
 import plotly.graph_objs as go
+from copy import deepcopy
 from plotly import subplots
 
 from qgis.core import (
@@ -97,7 +99,7 @@ class PlotFactory(QObject):  # pylint:disable=too-many-instance-attributes
         if settings is None:
             self.settings = PlotSettings('scatter')
         else:
-            self.settings = settings.clone()
+            self.settings = deepcopy(settings)
         self.context_generator = context_generator
         self.raw_plot = None
         self.plot_path = None

--- a/DataPlotly/core/plot_factory.py
+++ b/DataPlotly/core/plot_factory.py
@@ -95,9 +95,9 @@ class PlotFactory(QObject):  # pylint:disable=too-many-instance-attributes
                  visible_region: QgsReferencedRectangle = None, polygon_filter: FilterRegion = None):
         super().__init__()
         if settings is None:
-            settings = PlotSettings('scatter')
-
-        self.settings = settings
+            self.settings = PlotSettings('scatter')
+        else:
+            self.settings = settings.clone()
         self.context_generator = context_generator
         self.raw_plot = None
         self.plot_path = None

--- a/DataPlotly/core/plot_settings.py
+++ b/DataPlotly/core/plot_settings.py
@@ -6,6 +6,7 @@ the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
 """
 
+from copy import deepcopy
 from qgis.PyQt.QtCore import QFile, QIODevice
 from qgis.PyQt.QtXml import QDomDocument, QDomElement
 from qgis.core import QgsXmlUtils, QgsPropertyCollection, QgsPropertyDefinition
@@ -222,6 +223,45 @@ class PlotSettings:  # pylint: disable=too-many-instance-attributes
         # multiple_dock
         self.dock_title = dock_title
         self.dock_id = dock_id
+
+    def clone(self) -> 'PlotSettings':
+        """
+        Create a deep copy of PlotSettings.
+
+        Note that we can't just use deepcopy here, because of QgsPropertyCollection member
+        """
+        res = PlotSettings()
+        res.plot_base_dic = deepcopy(self.plot_base_dic)
+        res.data_defined_properties = QgsPropertyCollection(self.data_defined_properties)
+        res.properties = deepcopy(self.properties)
+        res.layout = deepcopy(self.layout)
+        res.plot_type = deepcopy(self.plot_type)
+
+        res.x = self.x[:]
+        res.y = self.y[:]
+        res.z = self.z[:]
+        res.feature_ids = self.feature_ids[:]
+        res.additional_hover_text = self.additional_hover_text[:]
+        res.data_defined_marker_sizes = self.data_defined_marker_sizes[:]
+        res.data_defined_colors = self.data_defined_colors[:]
+        res.data_defined_stroke_colors = self.data_defined_stroke_colors[:]
+        res.data_defined_stroke_widths = self.data_defined_stroke_widths[:]
+
+        res.data_defined_title = self.data_defined_title
+        res.data_defined_legend_title = self.data_defined_legend_title
+        res.data_defined_x_title = self.data_defined_x_title
+        res.data_defined_y_title = self.data_defined_y_title
+        res.data_defined_z_title = self.data_defined_z_title
+        res.data_defined_x_min = self.data_defined_x_min
+        res.data_defined_x_max = self.data_defined_x_max
+        res.data_defined_y_min = self.data_defined_y_min
+        res.data_defined_y_max = self.data_defined_y_max
+        res.source_layer_id = self.source_layer_id
+
+        res.dock_title = self.dock_title
+        res.dock_id = self.dock_id
+
+        return res
 
     def write_xml(self, document: QDomDocument):
         """

--- a/DataPlotly/core/plot_settings.py
+++ b/DataPlotly/core/plot_settings.py
@@ -11,6 +11,10 @@ from qgis.PyQt.QtCore import QFile, QIODevice
 from qgis.PyQt.QtXml import QDomDocument, QDomElement
 from qgis.core import QgsXmlUtils, QgsPropertyCollection, QgsPropertyDefinition
 
+def _pc_deepcopy(self, memo):
+    return QgsPropertyCollection(self)
+
+QgsPropertyCollection.__deepcopy__ = _pc_deepcopy
 
 class PlotSettings:  # pylint: disable=too-many-instance-attributes
     """
@@ -223,45 +227,6 @@ class PlotSettings:  # pylint: disable=too-many-instance-attributes
         # multiple_dock
         self.dock_title = dock_title
         self.dock_id = dock_id
-
-    def clone(self) -> 'PlotSettings':
-        """
-        Create a deep copy of PlotSettings.
-
-        Note that we can't just use deepcopy here, because of QgsPropertyCollection member
-        """
-        res = PlotSettings()
-        res.plot_base_dic = deepcopy(self.plot_base_dic)
-        res.data_defined_properties = QgsPropertyCollection(self.data_defined_properties)
-        res.properties = deepcopy(self.properties)
-        res.layout = deepcopy(self.layout)
-        res.plot_type = deepcopy(self.plot_type)
-
-        res.x = self.x[:]
-        res.y = self.y[:]
-        res.z = self.z[:]
-        res.feature_ids = self.feature_ids[:]
-        res.additional_hover_text = self.additional_hover_text[:]
-        res.data_defined_marker_sizes = self.data_defined_marker_sizes[:]
-        res.data_defined_colors = self.data_defined_colors[:]
-        res.data_defined_stroke_colors = self.data_defined_stroke_colors[:]
-        res.data_defined_stroke_widths = self.data_defined_stroke_widths[:]
-
-        res.data_defined_title = self.data_defined_title
-        res.data_defined_legend_title = self.data_defined_legend_title
-        res.data_defined_x_title = self.data_defined_x_title
-        res.data_defined_y_title = self.data_defined_y_title
-        res.data_defined_z_title = self.data_defined_z_title
-        res.data_defined_x_min = self.data_defined_x_min
-        res.data_defined_x_max = self.data_defined_x_max
-        res.data_defined_y_min = self.data_defined_y_min
-        res.data_defined_y_max = self.data_defined_y_max
-        res.source_layer_id = self.source_layer_id
-
-        res.dock_title = self.dock_title
-        res.dock_id = self.dock_id
-
-        return res
 
     def write_xml(self, document: QDomDocument):
         """


### PR DESCRIPTION
Otherwise things get murky when we re-use the same settings objects with multiple factories, as the factory plot generation logic modifies settings (eg by recording the list of found feature ids)

Fixes incomplete plots when used with atlas