### PR TITLE
Add link to docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Test plugin](https://github.com/ghtmtt/DataPlotly/actions/workflows/test_plugin.yaml/badge.svg)](https://github.com/ghtmtt/DataPlotly/actions/workflows/test_plugin.yaml)
 [![Transifex 🗺](https://github.com/ghtmtt/DataPlotly/actions/workflows/transifex.yml/badge.svg)](https://github.com/ghtmtt/DataPlotly/actions/workflows/transifex.yml)
 
+**Documentation: https://dataplotly-docs.readthedocs.io/en/latest/intro.html**
+
 The DataPlotly plugin allows creation of [D3](https://d3js.org/)-like
 interactive plots directly within QGIS, thanks to the [Plotly](https://plot.ly/python/)
 library and its Python API.


### PR DESCRIPTION
I noticed the docs inside the plugin, but couldn't find a reference here. Later I saw it is hosted in a seperate repo, https://github.com/ghtmtt/DataPlotly-docs. Shall we add this URL to the README?

You can also consider putting this under website in this repo's GitHub about box.