### PR TITLE
Fix ValueError with Plotly >= 6 by moving titlefont to title.font

### DIFF
--- a/DataPlotly/core/plot_types/plot_type.py
+++ b/DataPlotly/core/plot_types/plot_type.py
@@ -109,11 +109,13 @@ class PlotType:
             legend={'orientation': settings.layout['legend_orientation']},
             title=title,
             xaxis={
-                'title': x_title,
-                'titlefont': {
-                    "size": settings.layout.get('font_xlabel_size', 10),
-                    "color": settings.layout.get('font_xlabel_color', "#000"),
-                    "family": settings.layout.get('font_xlabel_family', "Arial"),
+                'title': {
+                    'text': x_title,
+                    'font': {
+                        "size": settings.layout.get('font_xlabel_size', 10),
+                        "color": settings.layout.get('font_xlabel_color', "#000"),
+                        "family": settings.layout.get('font_xlabel_family', "Arial"),
+                },
                 },
                 'autorange': settings.layout['x_inv'],
                 'range': range_x,
@@ -125,11 +127,13 @@ class PlotType:
                 'gridcolor': settings.layout.get('gridcolor', '#bdbfc0')
             },
             yaxis={
-                'title': y_title,
-                'titlefont': {
-                    "size": settings.layout.get('font_ylabel_size', 10),
-                    "color": settings.layout.get('font_ylabel_color', "#000"),
-                    "family": settings.layout.get('font_ylabel_family', "Arial"),
+                'title': {
+                    'text': y_title,
+                    'font': {
+                        "size": settings.layout.get('font_ylabel_size', 10),
+                        "color": settings.layout.get('font_ylabel_color', "#000"),
+                        "family": settings.layout.get('font_ylabel_family', "Arial"),
+                    },
                 },
                 'autorange': settings.layout['y_inv'],
                 'range': range_y,


### PR DESCRIPTION
With plotly 6 installed and DataPlotly enabled, opening any QGIS project (without any plotting) raises a ValueError. In Plotly 6, passing a string to title and using titlefont on axes is no longer supported. Use title.text and title.font instead. The fixed version also works in Plotly 5, currently shipped with QGIS.

Related links to plotly:
https://github.com/plotly/plotly.py/releases/tag/v6.0.0rc0
https://github.com/plotly/plotly.js/pull/7212


Tested on Linux Mint 21.2 with the following setups:
- QGIS 3.42.1, Plotly 6.0.1
- QGIS 3.40.3, Plotly 5.4.0


**Traceback**
ValueError: Invalid property specified for object of type plotly.graph_objs.layout.XAxis: 'titlefont' Did you mean "tickfont"?
Traceback (most recent call last):
  File "/home/riannek/.local/share/QGIS/QGIS3/profiles/default/python/plugins/DataPlotly/gui/plot_settings_widget.py", line 1677, in read_project
    self.create_plot()
  File "/home/riannek/.local/share/QGIS/QGIS3/profiles/default/python/plugins/DataPlotly/gui/plot_settings_widget.py", line 1417, in create_plot
    plot_factory = self.create_plot_factory()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/riannek/.local/share/QGIS/QGIS3/profiles/default/python/plugins/DataPlotly/gui/plot_settings_widget.py", line 1373, in create_plot_factory
    plot_factory = PlotFactory(settings, visible_region=visible_region)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/riannek/.local/share/QGIS/QGIS3/profiles/default/python/plugins/DataPlotly/core/plot_factory.py", line 117, in __init__
    self.rebuild()
  File "/home/riannek/.local/share/QGIS/QGIS3/profiles/default/python/plugins/DataPlotly/core/plot_factory.py", line 446, in rebuild
    self.layout = self._build_layout()
                  ^^^^^^^^^^^^^^^^^^^^
  File "/home/riannek/.local/share/QGIS/QGIS3/profiles/default/python/plugins/DataPlotly/core/plot_factory.py", line 476, in _build_layout
    return PlotFactory.PLOT_TYPES[self.settings.plot_type].create_layout(self.settings)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/riannek/.local/share/QGIS/QGIS3/profiles/default/python/plugins/DataPlotly/core/plot_types/scatter.py", line 70, in create_layout
    layout = super(ScatterPlotFactory, ScatterPlotFactory).create_layout(settings)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/riannek/.local/share/QGIS/QGIS3/profiles/default/python/plugins/DataPlotly/core/plot_types/plot_type.py", line 107, in create_layout
    layout = graph_objs.Layout(
             ^^^^^^^^^^^^^^^^^^
  File "/home/riannek/miniconda3/envs/proj/lib/python3.12/site-packages/plotly/graph_objs/_layout.py", line 7188, in __init__
    self["xaxis"] = _v
    ~~~~^^^^^^^^^
  File "/home/riannek/miniconda3/envs/proj/lib/python3.12/site-packages/plotly/basedatatypes.py", line 5898, in __setitem__
    super(BaseLayoutHierarchyType, self).__setitem__(prop, value)
  File "/home/riannek/miniconda3/envs/proj/lib/python3.12/site-packages/plotly/basedatatypes.py", line 4852, in __setitem__
    self._set_compound_prop(prop, value)
  File "/home/riannek/miniconda3/envs/proj/lib/python3.12/site-packages/plotly/basedatatypes.py", line 5263, in _set_compound_prop
    val = validator.validate_coerce(val, skip_invalid=self._skip_invalid)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/riannek/miniconda3/envs/proj/lib/python3.12/site-packages/_plotly_utils/basevalidators.py", line 2504, in validate_coerce
    v = self.data_class(v, skip_invalid=skip_invalid, _validate=_validate)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/riannek/miniconda3/envs/proj/lib/python3.12/site-packages/plotly/graph_objs/layout/_xaxis.py", line 4493, in __init__
    self._process_kwargs(**dict(arg, **kwargs))
  File "/home/riannek/miniconda3/envs/proj/lib/python3.12/site-packages/plotly/basedatatypes.py", line 4378, in _process_kwargs
    raise err
ValueError: Invalid property specified for object of type plotly.graph_objs.layout.XAxis: 'titlefont'

Did you mean "tickfont"?