### PR TITLE
add legend style option : size, front, color

### DIFF
--- a/DataPlotly/core/plot_settings.py
+++ b/DataPlotly/core/plot_settings.py
@@ -51,6 +51,9 @@ class PlotSettings:  # pylint: disable=too-many-instance-attributes
     PROPERTY_FONT_YTICKS_SIZE = 27
     PROPERTY_FONT_YTICKS_FAMILY = 28
     PROPERTY_FONT_YTICKS_COLOR = 29
+    PROPERTY_FONT_LEGEND_SIZE = 27
+    PROPERTY_FONT_LEGEND_FAMILY = 28
+    PROPERTY_FONT_LEGEND_COLOR = 29
 
     DYNAMIC_PROPERTIES = {
         PROPERTY_FILTER: QgsPropertyDefinition('filter', 'Feature filter', QgsPropertyDefinition.Boolean),
@@ -77,6 +80,9 @@ class PlotSettings:  # pylint: disable=too-many-instance-attributes
         PROPERTY_FONT_YTICKS_SIZE: QgsPropertyDefinition('font_yticks_size', 'Font yticks size', QgsPropertyDefinition.String),
         PROPERTY_FONT_YTICKS_FAMILY: QgsPropertyDefinition('font_yticks_family', 'Font yticks family', QgsPropertyDefinition.String),
         PROPERTY_FONT_YTICKS_COLOR: QgsPropertyDefinition('font_yticks_color', 'Font yticks color', QgsPropertyDefinition.ColorWithAlpha),
+        PROPERTY_FONT_LEGEND_SIZE: QgsPropertyDefinition('font_legend_size', 'Font yticks size', QgsPropertyDefinition.String),
+        PROPERTY_FONT_LEGEND_FAMILY: QgsPropertyDefinition('font_legend_family', 'Font yticks family', QgsPropertyDefinition.String),
+        PROPERTY_FONT_LEGEND_COLOR: QgsPropertyDefinition('font_legend_color', 'Font yticks color', QgsPropertyDefinition.ColorWithAlpha),
         PROPERTY_X_TITLE: QgsPropertyDefinition('x_title', 'X title', QgsPropertyDefinition.String),
         PROPERTY_Y_TITLE: QgsPropertyDefinition('y_title', 'Y title', QgsPropertyDefinition.String),
         PROPERTY_Z_TITLE: QgsPropertyDefinition('z_title', 'Z title', QgsPropertyDefinition.String),
@@ -162,6 +168,9 @@ class PlotSettings:  # pylint: disable=too-many-instance-attributes
             'font_yticks_size': 10,
             'font_yticks_family': "Arial",
             'font_yticks_color': "#000000",
+            'font_legend_size': 10,
+            'font_legend_family': "Arial",
+            'font_legend_color': "#000000",
             'xaxis': None,
             'bar_mode': None,
             'x_type': None,

--- a/DataPlotly/core/plot_types/plot_type.py
+++ b/DataPlotly/core/plot_types/plot_type.py
@@ -106,7 +106,14 @@ class PlotType:
 
         layout = graph_objs.Layout(
             showlegend=settings.layout['legend'],
-            legend={'orientation': settings.layout['legend_orientation']},
+            legend={'orientation': settings.layout['legend_orientation'],
+                    'font': {
+                        'size': settings.layout.get('font_legend_size', 10),
+                        'color': settings.layout.get('font_legend_color', "#000"),
+                        'family': settings.layout.get('font_legend_family', "Arial"),
+                    }
+                    },
+
             title=title,
             xaxis={
                 'title': x_title,

--- a/DataPlotly/gui/plot_settings_widget.py
+++ b/DataPlotly/gui/plot_settings_widget.py
@@ -924,14 +924,17 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
             self.font_xticks_label: ['all'],
             self.font_ylabel_label: ['all'],
             self.font_yticks_label: ['all'],
+            self.font_legend_label: ['all'],
             self.font_title_style: ['all'],
             self.font_xlabel_style: ['all'],
             self.font_xticks_style: ['all'],
             self.font_ylabel_style: ['all'],
             self.font_yticks_style: ['all'],
+            self.font_legend_style: ['all'],
             self.font_title_color: ['all'],
             self.font_xlabel_color: ['all'],
             self.font_xticks_color: ['all'],
+            self.font_legend_color: ['all'],
             self.font_ylabel_color: ['all'],
             self.font_yticks_color: ['all'],
             self.x_axis_label: ['scatter', 'bar', 'box', 'histogram', '2dhistogram', 'ternary', 'violin'],
@@ -1172,6 +1175,11 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
             self.font_yticks_style.currentFont().pointSize()),
             'font_yticks_family': self.font_yticks_style.currentFont().family(),
             'font_yticks_color': self.font_yticks_color.color().name(),
+            'font_legend_size': max(
+            self.font_legend_style.currentFont().pixelSize(),
+            self.font_legend_style.currentFont().pointSize()),
+            'font_legend_family': self.font_legend_style.currentFont().family(),
+            'font_legend_color': self.font_legend_color.color().name(),
             'x_title': self.x_axis_title.text(),
             'y_title': self.y_axis_title.text(),
             'z_title': self.z_axis_title.text(),
@@ -1291,6 +1299,11 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
                   settings.layout.get('font_yticks_size', 10)))
         self.font_yticks_color.setColor(
             QColor(settings.layout.get('font_yticks_color', "#000000")))
+        self.font_legend_style.setCurrentFont(
+            QFont(settings.layout.get('font_legend_style', "Arial"),
+                  settings.layout.get('font_legend_size', 10)))
+        self.font_legend_color.setColor(
+            QColor(settings.layout.get('font_legend_color', "#000000")))
         self.font_ylabel_style.setCurrentFont(
             QFont(settings.layout.get('font_ylabel_family', "Arial"),
                   settings.layout.get('font_ylabel_size', 10)))

--- a/DataPlotly/ui/dataplotly_dockwidget_base.ui
+++ b/DataPlotly/ui/dataplotly_dockwidget_base.ui
@@ -1255,6 +1255,13 @@ QListWidget::item::selected {
                          </property>
                         </widget>
                        </item>
+                       <item row="7" column="0">
+                        <widget class="QLabel" name="font_legend_label">
+                         <property name="text">
+                          <string>Legend font</string>
+                         </property>
+                        </widget>
+                       </item>
                        <item row="0" column="0">
                         <widget class="QLabel" name="font_title_label">
                          <property name="text">
@@ -1286,6 +1293,13 @@ QListWidget::item::selected {
                          </property>
                         </widget>
                        </item>
+                       <item row="7" column="2">
+                        <widget class="QgsFontButton" name="font_legend_style">
+                         <property name="mode">
+                          <enum>QgsFontButton::ModeQFont</enum>
+                         </property>
+                        </widget>
+                       </item>
                        <item row="5" column="2">
                         <widget class="QgsFontButton" name="font_ylabel_style">
                          <property name="mode">
@@ -1302,6 +1316,9 @@ QListWidget::item::selected {
                        </item>
                        <item row="3" column="3">
                         <widget class="QgsColorButton" name="font_xlabel_color"/>
+                       </item>
+                       <item row="7" column="3">
+                        <widget class="QgsColorButton" name="font_legend_color"/>
                        </item>
                        <item row="3" column="2">
                         <widget class="QgsFontButton" name="font_xlabel_style">


### PR DESCRIPTION
Add style option for all plot type. With the implementation of :
- PROPERTY_FONT_LEGEND_SIZE
- PROPERTY_FONT_LEGEND_FAMILY
- PROPERTY_FONT_LEGEND_COLOR

Funded by [INRAE - Reversaal](https://reversaal.inrae.fr/)

![Capture d’écran du 2025-05-06 14-58-03](https://github.com/user-attachments/assets/006c5003-7bd3-4a42-9871-7460411aacf9)

![Capture d’écran du 2025-05-06 14-51-03](https://github.com/user-attachments/assets/e4485e5d-011d-4899-bf3d-a63f8559f964)
