### PR TITLE
GH Action - Upload with a QGIS token instead of OSGEO user and password

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,5 @@ jobs:
           release ${{ env.RELEASE_VERSION }}
           --github-token ${{ secrets.GITHUB_TOKEN }}
           --transifex-token ${{ secrets.TRANSIFEX_TOKEN }}
-          --osgeo-username ${{ secrets.OSGEO_USERNAME }}
-          --osgeo-password ${{ secrets.OSGEO_PASSWORD }}
+          --qgis-token ${{ secrets.QGIS_TOKEN }}
           --create-plugin-repo


### PR DESCRIPTION
Just a switch from legacy user&password to a token.

On https://plugins.qgis.org, create the token in your plugin settings, and copy/paste in a GitHub settings -> Secretes and variable -> Actions -> New repository secret -> `QGIS_TOKEN`, and you should remove `OSGEO_USERNAME` and `OSGEO_PASSWORD`.