### PR TITLE
Simplify code for QGIS 3 and QGIS 4

### DIFF
--- a/DataPlotly/__init__.py
+++ b/DataPlotly/__init__.py
@@ -46,7 +46,4 @@ def serverClassFactory(server_iface):
     from DataPlotly.layouts.plot_layout_item import PlotLayoutItemMetadata
 
     QgsApplication.layoutItemRegistry().addLayoutItemType(PlotLayoutItemMetadata())
-    if Qgis.versionInt() >= 40000:
-        QgsMessageLog.logMessage("Custom DataPlotly layout item loaded", "DataPlotly", Qgis.MessageLevel.Info)
-    else:
-        QgsMessageLog.logMessage("Custom DataPlotly layout item loaded", "DataPlotly", Qgis.Info)
+    QgsMessageLog.logMessage("Custom DataPlotly layout item loaded", "DataPlotly", Qgis.MessageLevel.Info)

--- a/DataPlotly/core/plot_factory.py
+++ b/DataPlotly/core/plot_factory.py
@@ -78,11 +78,12 @@ class PlotFactory(QObject):  # pylint:disable=too-many-instance-attributes
     POLY_FILL_PATH = QUrl.fromLocalFile(
         os.path.realpath(os.path.join(os.path.dirname(__file__), '..', 'jsscripts/polyfill.min.js'))).toString()
     if Qgis.versionInt() >= 40000:
-        PLOTLY_PATH = QUrl.fromLocalFile(
-            os.path.realpath(os.path.join(os.path.dirname(__file__), '..', 'jsscripts/plotly-3.0.1.min.js'))).toString()
+        plotly_version = "3.0.1"
     else:
-        PLOTLY_PATH = QUrl.fromLocalFile(
-            os.path.realpath(os.path.join(os.path.dirname(__file__), '..', 'jsscripts/plotly-1.52.2.min.js'))).toString()
+        plotly_version = "1.52.2"
+
+    PLOTLY_PATH = QUrl.fromLocalFile(
+        os.path.realpath(os.path.join(os.path.dirname(__file__), '..', f'jsscripts/plotly-{plotly_version}.min.js'))).toString()
 
     PLOT_TYPES = {
         t.type_name(): t for t in PlotType.__subclasses__()
@@ -90,17 +91,11 @@ class PlotFactory(QObject):  # pylint:disable=too-many-instance-attributes
 
     plot_built = pyqtSignal()
 
-    if Qgis.versionInt() >= 40000:
-        # Add function to QDate and QDateTime classes that the PlotlyJSONEncoder expects from date objects
-        if not hasattr(QDate, 'isoformat'):
-            QDate.isoformat = lambda d: d.toString(Qt.DateFormat.ISODate)
-        if not hasattr(QDateTime, 'isoformat'):
-            QDateTime.isoformat = lambda d: d.toString(Qt.DateFormat.ISODate)
-    else:
-        if not hasattr(QDate, 'isoformat'):
-            QDate.isoformat = lambda d: d.toString(Qt.ISODate)
-        if not hasattr(QDateTime, 'isoformat'):
-            QDateTime.isoformat = lambda d: d.toString(Qt.ISODate)
+    # Add function to QDate and QDateTime classes that the PlotlyJSONEncoder expects from date objects
+    if not hasattr(QDate, 'isoformat'):
+        QDate.isoformat = lambda d: d.toString(Qt.DateFormat.ISODate)
+    if not hasattr(QDateTime, 'isoformat'):
+        QDateTime.isoformat = lambda d: d.toString(Qt.DateFormat.ISODate)
 
     def __init__(self, settings: PlotSettings = None, context_generator: QgsExpressionContextGenerator = None,
                  visible_region: QgsReferencedRectangle = None, polygon_filter: FilterRegion = None):
@@ -201,10 +196,7 @@ class PlotFactory(QObject):  # pylint:disable=too-many-instance-attributes
         request.setSubsetOfAttributes(attrs, self.source_layer.fields())
 
         if not x_needs_geom and not y_needs_geom and not z_needs_geom and not additional_needs_geom and not self.settings.data_defined_properties.hasActiveProperties():
-            if Qgis.versionInt() >= 40000:
-                request.setFlags(QgsFeatureRequest.Flag.NoGeometry)
-            else:
-                request.setFlags(QgsFeatureRequest.NoGeometry)
+            request.setFlags(QgsFeatureRequest.Flag.NoGeometry)
 
         visible_geom_engine = None
         if self.settings.properties.get('visible_features_only', False) and self.visible_region is not None:

--- a/DataPlotly/core/plot_settings.py
+++ b/DataPlotly/core/plot_settings.py
@@ -338,17 +338,10 @@ class PlotSettings:  # pylint: disable=too-many-instance-attributes
         Reads the settings from an XML file
         """
         f = QFile(file_name)
-        if Qgis.versionInt() >= 40000:
-            if f.open(QIODevice.OpenModeFlag.ReadOnly):
-                document = QDomDocument()
-                if document.setContent(f):
-                    if self.read_xml(document.firstChildElement()):
-                        return True
-        else:
-            if f.open(QIODevice.ReadOnly):
-                document = QDomDocument()
-                if document.setContent(f):
-                    if self.read_xml(document.firstChildElement()):
-                        return True
+        if f.open(QIODevice.OpenModeFlag.ReadOnly):
+            document = QDomDocument()
+            if document.setContent(f):
+                if self.read_xml(document.firstChildElement()):
+                    return True
 
         return False

--- a/DataPlotly/data_plotly.py
+++ b/DataPlotly/data_plotly.py
@@ -141,10 +141,7 @@ class DataPlotly:  # pylint: disable=too-many-instance-attributes
         self.toolButton = QToolButton()
         self.toolButtonMenu = QMenu()
         self.toolButton.setMenu(self.toolButtonMenu)
-        if Qgis.versionInt() >= 40000:
-            self.toolButton.setPopupMode(QToolButton.ToolButtonPopupMode.MenuButtonPopup)
-        else:
-            self.toolButton.setPopupMode(QToolButton.MenuButtonPopup)
+        self.toolButton.setPopupMode(QToolButton.ToolButtonPopupMode.MenuButtonPopup)
         self.toolBtnAction = self.iface.addToolBarWidget(self.toolButton)
         self.toolButton.setDefaultAction(self.show_dock_action)
 

--- a/DataPlotly/gui/add_new_dock_dlg.py
+++ b/DataPlotly/gui/add_new_dock_dlg.py
@@ -31,12 +31,8 @@ class DataPlotlyNewDockDialog(QDialog, WIDGET):
 
     def update_dlg(self, state, msg):
         """validator slot"""
-        if Qgis.versionInt() >= 40000:
-            is_valid = state != QValidator.State.Intermediate
-            self.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setEnabled(is_valid)
-        else:
-            is_valid = state != QValidator.Intermediate
-            self.buttonBox.button(QDialogButtonBox.Ok).setEnabled(is_valid)
+        is_valid = state != QValidator.State.Intermediate
+        self.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setEnabled(is_valid)
         label = self.DockIdInformationLabel
         lineEdit = self.DockIdLineEdit
         style_border = ""
@@ -75,31 +71,19 @@ class DataPlotlyNewDockIdValidator(QValidator):
 
     def validate(self, dock_id, pos):
         """Checks if dock_id is not empty and not is already present"""
-        if Qgis.versionInt() >= 40000:
-            state = QValidator.State.Acceptable
-        else:
-            state = QValidator.Acceptable
+        state = QValidator.State.Acceptable
         msg = None
 
         if dock_id == "":
-            if Qgis.versionInt() >= 40000:
-                state = QValidator.State.Intermediate
-            else:
-                state = QValidator.Intermediate
+            state = QValidator.State.Intermediate
             msg = self.tr('DockId can not be empty')
 
         if dock_id in self.dock_widgets:
-            if Qgis.versionInt() >= 40000:
-                state = QValidator.State.Intermediate
-            else:
-                state = QValidator.Intermediate
+            state = QValidator.State.Intermediate
             msg = self.tr(f'DockId {dock_id} is already taken')
 
         if '_' in dock_id:
-            if Qgis.versionInt() >= 40000:
-                state = QValidator.State.Intermediate
-            else:
-                state = QValidator.Intermediate
+            state = QValidator.State.Intermediate
             msg = self.tr('The underscore _ is not allowed')
 
         self.validationChanged.emit(state, msg)

--- a/DataPlotly/gui/dock.py
+++ b/DataPlotly/gui/dock.py
@@ -60,26 +60,16 @@ class DataPlotlyDockManager():
     def addNewDockFromDlg(self):
         """ Open a dlg and add dock"""
         dlg = DataPlotlyNewDockDialog(self.dock_widgets)
-        if Qgis.versionInt() >= 40000:
-            if dlg.exec():
-                dock_title, dock_id = dlg.get_params()
-                self.addNewDock(dock_title, dock_id, False)
-        else:
-            if dlg.exec_():
-                dock_title, dock_id = dlg.get_params()
-                self.addNewDock(dock_title, dock_id, False)
+        if dlg.exec():
+            dock_title, dock_id = dlg.get_params()
+            self.addNewDock(dock_title, dock_id, False)
 
     def removeDockFromDlg(self):
         """ Open a dlg to remove a dock"""
         dlg = DataPlotlyRemoveDockDialog(self.dock_widgets)
-        if Qgis.versionInt() >= 40000:
-            if dlg.exec():
-                dock_id = dlg.get_param()
-                self.removeDock(dock_id)
-            else:
-                if dlg.exec_():
-                    dock_id = dlg.get_param()
-                    self.removeDock(dock_id)
+        if dlg.exec():
+            dock_id = dlg.get_param()
+            self.removeDock(dock_id)
 
     def addNewDock(self, dock_title='DataPlotly', dock_id='DataPlotly',  # pylint: disable=too-many-arguments
                    hide=True, message_bar=None, project=None):
@@ -96,10 +86,7 @@ class DataPlotlyDockManager():
         dock = DataPlotlyDock(
             dock_title=dock_title, message_bar=message_bar, dock_id=dock_id, project=project, override_iface=self.iface)
         self.dock_widgets[dock_id] = dock
-        if Qgis.versionInt() >= 40000:
-            self.iface.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, dock)
-        else:
-            self.iface.addDockWidget(Qt.RightDockWidgetArea, dock)
+        self.iface.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, dock)
         if hide:
             dock.hide()
         return dock

--- a/DataPlotly/gui/plot_settings_widget.py
+++ b/DataPlotly/gui/plot_settings_widget.py
@@ -479,10 +479,7 @@ class DataPlotlyPanelWidget(QgsPanelWidget, WIDGET):  # pylint: disable=too-many
         Sets the print layout linked with the widget, if in print layout mode
         """
         self.linked_map_combo.setCurrentLayout(print_layout)
-        if Qgis.versionInt() >= 40000:
-            self.linked_map_combo.setItemType(QgsLayoutItemRegistry.ItemType.LayoutMap)
-        else:
-            self.linked_map_combo.setItemType(QgsLayoutItemRegistry.LayoutMap)
+        self.linked_map_combo.setItemType(QgsLayoutItemRegistry.ItemType.LayoutMap)
 
     def set_plot_type(self, plot_type: str):
         """

--- a/DataPlotly/gui/remove_dock_dlg.py
+++ b/DataPlotly/gui/remove_dock_dlg.py
@@ -23,10 +23,7 @@ class DataPlotlyRemoveDockDialog(QDialog, WIDGET):
         dock_ids = [dock_id for dock_id in dock_widgets.keys() if dock_id != 'DataPlotly']
         self.DockIdsComboBox.addItems(dock_ids)
         for i, dock_id in enumerate(dock_ids):
-            if Qgis.versionInt() >= 40000:
-                self.DockIdsComboBox.setItemData(i, dock_widgets[dock_id].title, Qt.ItemDataRole.ToolTipRole)
-            else:
-                self.DockIdsComboBox.setItemData(i, dock_widgets[dock_id].title, Qt.ToolTipRole)
+            self.DockIdsComboBox.setItemData(i, dock_widgets[dock_id].title, Qt.ItemDataRole.ToolTipRole)
 
     def get_param(self):
         """Return the dock_id to delete"""

--- a/DataPlotly/layouts/plot_layout_item.py
+++ b/DataPlotly/layouts/plot_layout_item.py
@@ -37,10 +37,7 @@ from DataPlotly.core.plot_settings import PlotSettings
 from DataPlotly.core.plot_factory import PlotFactory, FilterRegion
 from DataPlotly.gui.gui_utils import GuiUtils
 
-if Qgis.versionInt() >= 40000:
-    ITEM_TYPE = QgsLayoutItemRegistry.ItemType.PluginItem + 1337
-else:
-    ITEM_TYPE = QgsLayoutItemRegistry.PluginItem + 1337
+ITEM_TYPE = QgsLayoutItemRegistry.ItemType.PluginItem + 1337
 
 
 if Qgis.versionInt() >= 40000:
@@ -68,10 +65,7 @@ class PlotLayoutItem(QgsLayoutItem):
 
     def __init__(self, layout):
         super().__init__(layout)
-        if Qgis.versionInt() >= 40000:
-            self.setCacheMode(QGraphicsItem.CacheMode.NoCache)
-        else:
-            self.setCacheMode(QGraphicsItem.NoCache)
+        self.setCacheMode(QGraphicsItem.CacheMode.NoCache)
         self.plot_settings = []
         self.plot_settings.append(PlotSettings())
         self.linked_map_uuid = ''


### PR DESCRIPTION
Just discovering your PR #420

The purpose of QGIS 4 is "no API break", the code for QGIS 4 works under QGIS 3, it was already the recommended code.

Did you see the HowTo with the "Manual conversion" at the bottom or use the script ? https://github.com/qgis/QGIS/wiki/Plugin-migration-to-be-compatible-with-Qt5-and-Qt6#manual-conversion
